### PR TITLE
docs(readme): merge cross-experiment bar charts into single figure

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,16 +65,6 @@ Two models cleared all gates; one failed with high error rate.
 
 **Verdict:** MiniMax and Kimi qualify as cost-effective delegates; DeepSeek unsuitable.
 
-```mermaid
-xychart-beta
-    title "Mean score per model -- Experiment 4 (gate threshold: 5.3)"
-    x-axis ["haiku-4.5 (baseline)", "minimax-m2.5", "kimi-k2.5", "deepseek-v3.2"]
-    y-axis "Mean total score (0-8)" 0 --> 8
-    bar [5.8, 6.0, 7.0, 1.0]
-```
-
-*Figure 1: Total score per run (0-8) for exp4 models and the Haiku-4.5 baseline. Bars show mean total score. Dashed line at 5.3 marks the gate 1 mean threshold. Scores from experiments/exp3-model-comparison/analysis.json (baseline) and experiments/exp4-model-comparison-r2/analysis.json (candidates).*
-
 ## Cross-Experiment Summary
 
 | Experiment | Phase | Baseline Mean | Candidates Tested | Passed | Failed/Excluded | Key Finding |
@@ -84,21 +74,13 @@ xychart-beta
 
 ```mermaid
 xychart-beta
-    title "Mean score per model -- Experiment 3 (all fail)"
-    x-axis ["haiku-4.5 (baseline)", "gemini-3-flash", "devstral-2512"]
+    title "Mean score per model -- all experiments (gate threshold: 5.3)"
+    x-axis ["haiku-4.5 (baseline)", "gemini-3-flash (exp3)", "devstral-2512 (exp3)", "minimax-m2.5 (exp4)", "kimi-k2.5 (exp4)", "deepseek-v3.2 (exp4)"]
     y-axis "Mean total score (0-8)" 0 --> 8
-    bar [5.8, 4.2, 3.0]
+    bar [5.8, 4.2, 3.0, 6.0, 7.0, 1.0]
 ```
 
-```mermaid
-xychart-beta
-    title "Mean score per model -- Experiment 4 (split outcome)"
-    x-axis ["haiku-4.5 (baseline)", "minimax-m2.5", "kimi-k2.5", "deepseek-v3.2"]
-    y-axis "Mean total score (0-8)" 0 --> 8
-    bar [5.8, 6.0, 7.0, 1.0]
-```
-
-*Figure 2: Mean total score per model across exp3 (discovery) and exp4 (validation). Haiku-4.5 baseline shown in both phases. Qwen3 Coder excluded (0 valid runs after 7 attempts). DeepSeek V3.2 note: n=3 valid runs, 40% error rate.*
+*Figure 1: Mean total score per model across exp3 (discovery) and exp4 (validation). Haiku-4.5 baseline shown once. Qwen3 Coder excluded (0 valid runs after 7 attempts). DeepSeek V3.2 note: n=3 valid runs, 40% error rate.*
 
 Cost and token efficiency data are in `efficiency.json` within each experiment directory. Costs are computed from session token counts at 2026-02-25 pricing; see `DATA_DICTIONARY.md` for schema details.
 
@@ -106,13 +88,13 @@ Cost and token efficiency data are in `efficiency.json` within each experiment d
 
 ![Criterion pass rate heatmap](figures/criterion-heatmap.png)
 
-*Figure 3: Pass rate per criterion (C1-C8) for all six evaluated models across exp3 and exp4. Values are the fraction of valid runs satisfying each binary criterion (0.0-1.0). Row order: baseline, passing candidates, failing candidates.*
+*Figure 2: Pass rate per criterion (C1-C8) for all six evaluated models across exp3 and exp4. Values are the fraction of valid runs satisfying each binary criterion (0.0-1.0). Row order: baseline, passing candidates, failing candidates.*
 
 ### Cost vs. Quality
 
 ![Cost vs quality scatter](figures/cost-quality-scatter.png)
 
-*Figure 4: Quality score (mean total, 0-8) vs. estimated cost per valid run (USD, log scale). Horizontal dashed lines mark the gate threshold (5.3) and Haiku-4.5 baseline mean (5.8). Green circles = passing candidates; red crosses = failing candidates; blue diamond = baseline.*
+*Figure 3: Quality score (mean total, 0-8) vs. estimated cost per valid run (USD, log scale). Horizontal dashed lines mark the gate threshold (5.3) and Haiku-4.5 baseline mean (5.8). Green circles = passing candidates; red crosses = failing candidates; blue diamond = baseline.*
 
 ## Repository Structure
 


### PR DESCRIPTION
## Summary

Replace the redundant exp4-only bar chart and the two separate exp3/exp4 cross-experiment bar charts with a single unified figure. Haiku-4.5 baseline now appears once; exp3 and exp4 candidates are labelled by experiment on the x-axis.

## Changes

- `README.md`: remove exp4-only bar chart (Figure 1), merge exp3 and exp4 bar charts into one, renumber figures 1-3 in document appearance order