### PR TITLE
docs(figures): add figure generation scripts

### DIFF
--- a/figures/cost-quality-scatter.py
+++ b/figures/cost-quality-scatter.py
@@ -1,0 +1,48 @@
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+from matplotlib.lines import Line2D
+
+models     = ["haiku-4.5", "kimi-k2.5", "minimax-m2.5", "gemini-3-flash", "devstral-2512", "deepseek-v3.2"]
+cost_usd   = [0.0222, 0.0122, 0.0043, 0.0021, 0.0025, 0.0011]
+mean_score = [5.8, 7.0, 6.0, 4.2, 3.0, 1.0]
+verdicts   = ["baseline", "pass", "pass", "fail", "fail", "fail"]
+
+colors  = {"baseline": "#1f77b4", "pass": "#2ca02c", "fail": "#d62728"}
+markers = {"baseline": "D", "pass": "o", "fail": "x"}
+offsets = {
+    "haiku-4.5":      (8, -12),
+    "kimi-k2.5":      (8,   4),
+    "minimax-m2.5":   (8, -12),
+    "gemini-3-flash": (8,   4),
+    "devstral-2512":  (8, -12),
+    "deepseek-v3.2":  (8,   4),
+}
+
+fig, ax = plt.subplots(figsize=(8, 5))
+
+ax.axhline(y=5.3, color="gray",    linestyle="--", linewidth=1)
+ax.axhline(y=5.8, color="#1f77b4", linestyle="--", linewidth=1, alpha=0.4)
+
+for m, c, s, v in zip(models, cost_usd, mean_score, verdicts):
+    ax.scatter(c, s, color=colors[v], marker=markers[v], s=120, zorder=5)
+    ax.annotate(m, (c, s), xytext=offsets[m], textcoords="offset points",
+                fontsize=9, ha="left", va="center")
+
+ax.set_xscale("log")
+ax.set_xlim(0.0005, 0.1)
+ax.set_ylim(0, 8.5)
+ax.set_xlabel("Estimated cost per run (USD, log scale)", fontsize=11)
+ax.set_ylabel("Mean total score (0-8)", fontsize=11)
+ax.set_title("Quality vs. Cost -- exp3 & exp4 candidates", fontsize=12)
+
+legend_elements = [
+    Line2D([0], [0], marker="D", color="w", markerfacecolor="#1f77b4", markersize=9, label="Baseline"),
+    Line2D([0], [0], marker="o", color="w", markerfacecolor="#2ca02c", markersize=9, label="Pass"),
+    Line2D([0], [0], marker="x", color="#d62728",                      markersize=9, label="Fail"),
+]
+ax.legend(handles=legend_elements, loc="lower right", fontsize=9)
+
+plt.tight_layout()
+plt.savefig("figures/cost-quality-scatter.png", dpi=150, bbox_inches="tight")
+print("Saved figures/cost-quality-scatter.png")

--- a/figures/criterion-heatmap.py
+++ b/figures/criterion-heatmap.py
@@ -1,0 +1,47 @@
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+import numpy as np
+
+models = [
+    'haiku-4.5\n(baseline)',
+    'kimi-k2.5\n(pass)',
+    'minimax-m2.5\n(pass)',
+    'gemini-3-flash\n(fail)',
+    'devstral-2512\n(fail)',
+    'deepseek-v3.2\n(fail)',
+]
+criteria = ['C1', 'C2', 'C3', 'C4', 'C5', 'C6', 'C7', 'C8']
+data = np.array([
+    [1.0, 1.0, 0.2, 1.0, 0.2, 0.4, 1.0, 1.0],  # haiku
+    [1.0, 1.0, 0.6, 1.0, 0.4, 1.0, 1.0, 1.0],  # kimi
+    [1.0, 1.0, 0.0, 1.0, 0.8, 0.4, 0.8, 1.0],  # minimax
+    [1.0, 1.0, 0.0, 0.8, 0.2, 0.0, 0.2, 1.0],  # gemini
+    [1.0, 0.8, 0.0, 0.0, 0.0, 0.0, 0.2, 1.0],  # devstral
+    [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0],  # deepseek
+])
+
+fig, ax = plt.subplots(figsize=(10, 5))
+cmap = plt.get_cmap('RdYlGn')
+im = ax.imshow(data, cmap=cmap, vmin=0, vmax=1, aspect='auto')
+
+ax.set_xticks(range(len(criteria)))
+ax.set_xticklabels(criteria, fontsize=11)
+ax.set_yticks(range(len(models)))
+ax.set_yticklabels(models, fontsize=10)
+
+for i in range(len(models)):
+    for j in range(len(criteria)):
+        val = data[i, j]
+        color = 'black' if 0.2 < val < 0.8 else ('white' if val < 0.3 else 'black')
+        ax.text(j, i, f'{val:.1f}', ha='center', va='center', fontsize=10, color=color, fontweight='bold')
+
+ax.axhline(y=0.5, color='#444', linewidth=1.5, linestyle='--')
+ax.axhline(y=2.5, color='#444', linewidth=1.5, linestyle='--')
+
+plt.colorbar(im, ax=ax, label='Pass rate (0.0 = never, 1.0 = always)')
+ax.set_title('Criterion pass rates across all evaluated models (exp3 + exp4)', fontsize=12, pad=12)
+
+plt.tight_layout()
+plt.savefig('figures/criterion-heatmap.png', dpi=150, bbox_inches='tight')
+print('Saved figures/criterion-heatmap.png')


### PR DESCRIPTION
## Summary

Add the Python scripts used to generate the two PNG figures in `figures/`. Scripts were previously run ephemerally and not committed.

## Changes

- `figures/criterion-heatmap.py`: generates `criterion-heatmap.png` (6-model x 8-criterion pass rate heatmap, matplotlib + numpy)
- `figures/cost-quality-scatter.py`: generates `cost-quality-scatter.png` (quality vs. cost scatter, post-label-overlap fix from PR #1)

Both scripts use hardcoded data from `analysis.json` and `efficiency.json`. Run with:

```
uvx --with matplotlib --with numpy python3 figures/criterion-heatmap.py
uvx --with matplotlib python3 figures/cost-quality-scatter.py
```

## Notes

- Script names match their output PNG names for clarity
- `cost-quality-scatter.py` reflects the label offset fix from PR #1, not the original version