### PR TITLE
docs: add Zenodo DOI 10.5281/zenodo.19056877

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,6 +10,10 @@ repository-code: https://github.com/clouatre-labs/llm-agent-experiments
 url: https://clouatre.ca/posts/orchestrating-ai-agents-subagent-architecture/
 license: Apache-2.0
 date-released: "2025-12-24"
+identifiers:
+  - type: doi
+    value: 10.5281/zenodo.19056877
+    description: Zenodo DOI
 version: "1.0.0"
 abstract: >
   Benchmarking open-weight LLM coding agents as SCOUT delegates in the

--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ If you use this dataset or methodology, please cite:
   title   = {Orchestrating AI Agents: A Subagent Architecture},
   author  = {Clouatre, Hugues},
   year    = {2026},
+  doi     = {10.5281/zenodo.19056877},
   howpublished = {\url{https://clouatre.ca/posts/orchestrating-ai-agents-subagent-architecture/}},
   urldate = {2026-03-16},
   note    = {Supplementary materials: https://github.com/clouatre-labs/llm-agent-experiments}


### PR DESCRIPTION
Adds Zenodo DOI to README.md BibTeX citation and CITATION.cff identifiers block following v1.0.0 release.