### PR TITLE
docs: add Zenodo concept DOI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.19056876.svg)](https://doi.org/10.5281/zenodo.19056876)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
-[![GitHub stars](https://img.shields.io/github/stars/clouatre-labs/llm-agent-experiments.svg?style=flat)](https://github.com/clouatre-labs/llm-agent-experiments)
 [![Sessions](https://img.shields.io/badge/sessions-28-green)](experiments/)
 [![Runs](https://img.shields.io/badge/runs-28-blue)](experiments/)
 


### PR DESCRIPTION
Adds Zenodo DOI badge using the concept DOI (resolves to latest version always). Also updates BibTeX `doi` field in README citation to use concept DOI instead of version DOI.