### PR TITLE
docs: add supplementary material link to blog post

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 Deploying LLM agents at scale demands cost-effective model selection for each role in a multi-agent pipeline. We investigate whether open-weight models can serve as drop-in replacements for a proprietary baseline (Claude Haiku 4.5) in a specialized research synthesis agent role, using a pre-registered, blinded 8-criterion binary rubric across two sequential experiments (7 models, 33 runs; approximately 4-5 runs per model (except DeepSeek V3.2: 3 valid due to infrastructure failures)). Candidate quality was evaluated against a Mann-Whitney U non-inferiority criterion (alpha=0.05). Two candidates meet all non-inferiority thresholds: Kimi K2.5 (mean 6.6/8) and MiniMax M2.5 (mean 6.4/8; API cost 87% lower than the baseline per run). Two candidates fail on reliability: Qwen3 Coder (0 of 7 valid runs) and DeepSeek V3.2 (40% error rate); Gemini 3 Flash, Devstral 2512, and Mistral Small 2603 also fail to meet quality thresholds. Results are limited to a single task type and pipeline configuration; generalizability to other agent roles requires further study. The evaluation protocol is released as a reusable template for role-level model substitution assessments in multi-agent systems.
 
+Supplementary materials for [Orchestrating AI Agents: Sub-Agent Architecture](https://clouatre.ca/posts/orchestrating-ai-agents-subagent-architecture/).
+
 </div>
 
 ## The Question


### PR DESCRIPTION
Adds a supplementary materials line below the abstract linking to the blog post, matching the pattern used in prompt-repetition-experiments.