### PR TITLE
fix: correct kimi-k2.5 efficiency data and documentation errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ All experiments used Goose 1.27.2 as the agent orchestrator. To reproduce:
 | Orchestrator model | Claude Sonnet 4.6 | GCP Vertex AI, temp 0.3 |
 | SCOUT delegate models | See exp3/exp4 protocol | Variable per experiment |
 
-*Table 3: Software versions used across all experiments.*
+*Table 4: Software versions used across all experiments.*
 
 ## Impact
 

--- a/experiments/exp3-model-comparison/README.md
+++ b/experiments/exp3-model-comparison/README.md
@@ -21,7 +21,7 @@ This experiment addresses cost reduction objectives outlined in [dotfiles issue 
 
 | Model | n valid | Scores | Mean | Verdict |
 |-------|---------|--------|------|---------|
-| Claude Haiku 4.5 (baseline) | 5 | 5, 5, 8, 6, 5 | 5.8 | baseline |
+| Claude Haiku 4.5 (baseline) | 5 | 5, 6, 7, 6, 5 | 5.8 | baseline |
 | Qwen3 Coder | 0 | n/a | n/a | excluded |
 | Gemini 3 Flash | 5 | 4, 4, 3, 5, 5 | 4.2 | fail (all gates) |
 | Devstral 2512 | 5 | 4, 3, 3, 3, 2 | 3.0 | fail (all gates) |

--- a/experiments/exp4-model-comparison-r2/efficiency.json
+++ b/experiments/exp4-model-comparison-r2/efficiency.json
@@ -273,9 +273,9 @@
       "n_valid": 5,
       "n_total_attempts": 6,
       "reliability": 0.8333,
-      "mean_score": 7.0,
+      "mean_score": 6.6,
       "cost_per_run_usd": 0.2206,
-      "eff_cost_per_qp_usd": 0.0378,
+      "eff_cost_per_qp_usd": 0.0401,
       "mean_wall_time_minutes": 11.64,
       "cost_token_basis": "accumulated"
     },


### PR DESCRIPTION
## Summary

Three data/documentation errors found by cross-referencing JSON sources against prose.

## Changes

- \`experiments/exp4-model-comparison-r2/efficiency.json\`: kimi-k2.5 \`mean_score\` 7.0 -> 6.6 (scores.json runs 31-35 sum to 33, mean 6.6); recomputed \`eff_cost_per_qp_usd\` 0.0378 -> 0.0401
- \`experiments/exp3-model-comparison/README.md\`: haiku baseline scores corrected from \`5,5,8,6,5\` to \`5,6,7,6,5\` (mean 5.8 was correct; individual scores were wrong)
- \`README.md\`: duplicate Table 3 caption renumbered; software versions table is now Table 4

## Test plan

- [ ] \`jq '.model_summaries["kimi-k2.5"]' experiments/exp4-model-comparison-r2/efficiency.json\` shows mean_score=6.6, eff_cost_per_qp_usd=0.0401
- [ ] \`jq '.baseline.scores' experiments/exp3-model-comparison/analysis.json\` matches exp3 README scores column
- [ ] No duplicate table captions in README.md