### PR TITLE
docs: rename Mistral Small 2603 to Mistral Small 4 across all prose

### DIFF
--- a/METHODOLOGY.md
+++ b/METHODOLOGY.md
@@ -49,7 +49,7 @@ Baseline reused (exp3 runs 1-5) and four new candidates, each n=5 (DeepSeek n=3 
 - **MiniMax M2.5:** Chinese Minimax, open-weight via OpenRouter
 - **DeepSeek V3.2:** Chinese DeepSeek, commercial API
 - **Kimi K2.5:** Chinese Moonshot, commercial API
-- **Mistral Small 2603:** Mistral AI, commercial API via OpenRouter
+- **Mistral Small 4 (`mistral-small-2603`):** Mistral AI, commercial API via OpenRouter
 
 ## Blinding Procedure
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Sessions](https://img.shields.io/badge/sessions-89-green)](experiments/)
 [![Runs](https://img.shields.io/badge/runs-89-blue)](experiments/)
 
-Deploying LLM agents at scale demands cost-effective model selection for each role in a multi-agent pipeline. We investigate whether open-weight models can serve as drop-in replacements for a proprietary baseline (Claude Haiku 4.5) in a specialized research synthesis agent role, using a pre-registered, blinded 8-criterion binary rubric across two sequential experiments (7 models, 33 runs; approximately 4-5 runs per model (except DeepSeek V3.2: 3 valid due to infrastructure failures)). Candidate quality was evaluated against a Mann-Whitney U non-inferiority criterion (alpha=0.05). Two candidates meet all non-inferiority thresholds: Kimi K2.5 (mean 6.6/8) and MiniMax M2.5 (mean 6.4/8; API cost 87% lower than the baseline per run). Two candidates fail on reliability: Qwen3 Coder (0 of 7 valid runs) and DeepSeek V3.2 (40% error rate); Gemini 3 Flash, Devstral 2512, and Mistral Small 2603 also fail to meet quality thresholds. Results are limited to a single task type and pipeline configuration; generalizability to other agent roles requires further study. The evaluation protocol is released as a reusable template for role-level model substitution assessments in multi-agent systems.
+Deploying LLM agents at scale demands cost-effective model selection for each role in a multi-agent pipeline. We investigate whether open-weight models can serve as drop-in replacements for a proprietary baseline (Claude Haiku 4.5) in a specialized research synthesis agent role, using a pre-registered, blinded 8-criterion binary rubric across two sequential experiments (7 models, 33 runs; approximately 4-5 runs per model (except DeepSeek V3.2: 3 valid due to infrastructure failures)). Candidate quality was evaluated against a Mann-Whitney U non-inferiority criterion (alpha=0.05). Two candidates meet all non-inferiority thresholds: Kimi K2.5 (mean 6.6/8) and MiniMax M2.5 (mean 6.4/8; API cost 87% lower than the baseline per run). Two candidates fail on reliability: Qwen3 Coder (0 of 7 valid runs) and DeepSeek V3.2 (40% error rate); Gemini 3 Flash, Devstral 2512, and Mistral Small 4 also fail to meet quality thresholds. Results are limited to a single task type and pipeline configuration; generalizability to other agent roles requires further study. The evaluation protocol is released as a reusable template for role-level model substitution assessments in multi-agent systems.
 
 Exp5 and exp6 extend coverage to all 7 pipeline roles. Exp6 evaluates `inception/mercury-2` (n=5 per role, 35 runs) and finds 100% correctness on BUILD, FIXER, CHECK, REVIEW, and QA, with a full pipeline wall time of 23s and $0.0124/pipeline cost.
 
@@ -41,14 +41,14 @@ Can open-weight models serve as drop-in replacements for a proprietary LLM basel
 | Claude Haiku 4.5 | 5 | 5.8 | 0.0 | baseline |
 | Kimi K2.5 | 5 | 6.6 | 0.0 | pass |
 | MiniMax M2.5 | 5 | 6.4 | 0.0 | pass |
-| Mistral Small 2603 | 5 | 5.4 | 0.375 | fail |
+| Mistral Small 4 | 5 | 5.4 | 0.375 | fail |
 | Gemini 3 Flash | 5 | 4.2 | 0.0 | fail |
 | Devstral 2512 | 5 | 3.0 | 0.0 | fail |
 | DeepSeek V3.2 | 3 | 1.0 | 0.4 | fail |
 | Qwen3 Coder | 0 | n/a | 1.0 | excluded (0/7 valid runs) |
 | Mercury 2 | 5 | 4.6 | 0.0 | fail |
 
-*Table 2: Per-model results. Baseline first, then sorted by mean score descending. Error rate = fraction of runs that failed to produce valid output. Exp3 = discovery round (Haiku 4.5, Qwen3 Coder, Gemini 3 Flash, Devstral 2512); exp4 = validation round (MiniMax M2.5, DeepSeek V3.2, Kimi K2.5, Mistral Small 2603); exp6 = Mercury 2 (frontmatter patch task, same 8-criterion rubric). Full data in experiments/. Mann-Whitney U p-values in analysis.json. Verdict requires passing all four gates: mean > 5.3, min score >= 5, n_valid >= 5, and Mann-Whitney non-inferiority (p >= 0.05 vs baseline). A model can fail despite a mean above the threshold if any other gate fails (e.g., Mistral Small 2603: mean=5.4 passes gate 1 but min score=4 fails gate 2).*
+*Table 2: Per-model results. Baseline first, then sorted by mean score descending. Error rate = fraction of runs that failed to produce valid output. Exp3 = discovery round (Haiku 4.5, Qwen3 Coder, Gemini 3 Flash, Devstral 2512); exp4 = validation round (MiniMax M2.5, DeepSeek V3.2, Kimi K2.5, Mistral Small 4); exp6 = Mercury 2 (frontmatter patch task, same 8-criterion rubric). Full data in experiments/. Mann-Whitney U p-values in analysis.json. Verdict requires passing all four gates: mean > 5.3, min score >= 5, n_valid >= 5, and Mann-Whitney non-inferiority (p >= 0.05 vs baseline). A model can fail despite a mean above the threshold if any other gate fails (e.g., Mistral Small 4: mean=5.4 passes gate 1 but min score=4 fails gate 2).*
 
 ### Mean Score
 
@@ -76,7 +76,7 @@ Composite metric: `eff_cost_per_qp = cost_per_run / (mean_score * reliability)`.
 
 | Model | Score | Cost/Run | Reliability | Eff. $/QP | Wall Time | Verdict |
 |-------|-------|----------|-------------|-----------|-----------|---------|
-| Mistral Small 2603 | 5.4 | $0.008 | 0.625 | **$0.002** | 1.8m | fail |
+| Mistral Small 4 | 5.4 | $0.008 | 0.625 | **$0.002** | 1.8m | fail |
 | MiniMax M2.5 | 6.4 | $0.115 | 1.000 | $0.018 | 5.1m | pass |
 | DeepSeek V3.2 | 1.0 | $0.007 | 0.333 | $0.021 | 2.1m | fail |
 | Gemini 3 Flash | 4.2 | $0.057 | 0.625 | $0.022 | 2.7m | fail |
@@ -233,7 +233,7 @@ All experiments used Goose 1.27.2 as the agent orchestrator. To reproduce:
 
 These experiments directly informed changes to the coder recipe. Following exp4 results and a parallel refactor of the `code-analyze` MCP server to reduce token overhead ([clouatre-labs/code-analyze-mcp#264](https://github.com/clouatre-labs/code-analyze-mcp/issues/264)), SCOUT was upgraded from Claude Haiku 4.5 to Claude Sonnet 4.6; the lower per-token cost of the compact MCP format made Sonnet viable at SCOUT's session length. The recipe was rewritten to define each agent role as a named subagent file, achieving cross-compatibility between Goose and Claude Code (see [blog post](https://clouatre.ca/posts/orchestrating-ai-agents-subagent-architecture/)). MiniMax M2.5 (exp4: mean 6.4/8, error rate 0.0) was adopted for GUARD with a reduced adversarial scope, replacing Haiku at lower cost.
 
-Exp5 and exp6 extend the evaluation to all 7 pipeline roles. Exp5 (n=1, three models: Haiku 4.5, Mistral Small 2603, MiniMax M2.5) established that Mistral Small 2603 is turn-efficient on execution roles (GUARD, BUILD, FIXER, REVIEW, QA). Exp6 (n=5, Mercury 2) finds that Mercury 2 (a diffusion LLM) achieves 100% correctness on BUILD, FIXER, CHECK, REVIEW, and QA roles with 1.8-3.6s wall time per role and $0.0124/pipeline total cost, making it the fastest model evaluated. Mercury 2 GUARD shows an 80% pass rate (one false revise verdict in 5 runs). SCOUT remains on Claude Sonnet 4.6.
+Exp5 and exp6 extend the evaluation to all 7 pipeline roles. Exp5 (n=1, three models: Haiku 4.5, Mistral Small 4, MiniMax M2.5) established that Mistral Small 4 is turn-efficient on execution roles (GUARD, BUILD, FIXER, REVIEW, QA). Exp6 (n=5, Mercury 2) finds that Mercury 2 (a diffusion LLM) achieves 100% correctness on BUILD, FIXER, CHECK, REVIEW, and QA roles with 1.8-3.6s wall time per role and $0.0124/pipeline total cost, making it the fastest model evaluated. Mercury 2 GUARD shows an 80% pass rate (one false revise verdict in 5 runs). SCOUT remains on Claude Sonnet 4.6.
 
 ## Limitations
 

--- a/experiments/exp4-model-comparison-r2/METHODOLOGY.md
+++ b/experiments/exp4-model-comparison-r2/METHODOLOGY.md
@@ -2,7 +2,7 @@
 
 ## Experimental Design
 
-Four candidates tested against Claude Haiku 4.5 baseline (reused from exp3). 5 runs per candidate (DeepSeek V3.2: 3 valid from 9 total attempts; Mistral Small 2603: 5 valid from 8 total attempts). Blind scoring protocol applied uniformly across all candidates.
+Four candidates tested against Claude Haiku 4.5 baseline (reused from exp3). 5 runs per candidate (DeepSeek V3.2: 3 valid from 9 total attempts; Mistral Small 4: 5 valid from 8 total attempts). Blind scoring protocol applied uniformly across all candidates.
 
 ## Blinding Procedure
 
@@ -10,7 +10,7 @@ Four candidates tested against Claude Haiku 4.5 baseline (reused from exp3). 5 r
 - Scorer receives run IDs only (no model names or identifying information)
 - Scores recorded in scores.json with per-criterion justifications
 - Label map revealed only after all scoring complete
-- Mistral Small 2603 (runs 36-40) scored in a separate session using identical blinding protocol
+- Mistral Small 4 (runs 36-40) scored in a separate session using identical blinding protocol
 
 ## Rubric
 
@@ -31,7 +31,7 @@ Note: C3 criterion was refined from exp3 (now requires explicit acknowledgment o
 
 - Scorer: mistral-large (blind to run identity)
 - Scores recorded in scores.json with per-criterion justification notes
-- Mistral Small 2603 blind scores with justifications in scores-mistral.json
+- Mistral Small 4 blind scores with justifications in scores-mistral.json
 - All criterion scores are binary (0 or 1)
 
 ## Gate Criteria
@@ -65,7 +65,7 @@ Costs based on OpenRouter pricing (as of experiment run date). Token counts accu
 
 Runs 27 and 30 produced no parseable JSON output after 3 attempts each. Both logged in latency-log.jsonl. n_total_attempts=9 (run-26: 1, run-27: 3, run-28: 1, run-29: 1, run-30: 3). Reliability = 3/9 = 0.33.
 
-### Mistral Small 2603
+### Mistral Small 4
 
 8 total attempts across 5 run slots. Reliability = 5/8 = 0.625. Passes mean gate (5.4 > 5.3) but fails gate_2 (min score 4 < threshold 5). Criterion pass rates: C1=1.0, C2=1.0, C3=0.0, C4=1.0, C5=0.0, C6=0.6, C7=0.6, C8=1.0. Mann-Whitney p=1.0 (no significant difference vs baseline).
 

--- a/experiments/exp4-model-comparison-r2/README.md
+++ b/experiments/exp4-model-comparison-r2/README.md
@@ -2,7 +2,7 @@
 
 ## Research Question
 
-Do higher-tier open-weight models (MiniMax M2.5, DeepSeek V3.2, Kimi K2.5, Mistral Small 2603) provide viable SCOUT delegate candidates while maintaining reasonable cost?
+Do higher-tier open-weight models (MiniMax M2.5, DeepSeek V3.2, Kimi K2.5, Mistral Small 4) provide viable SCOUT delegate candidates while maintaining reasonable cost?
 
 ## Context
 
@@ -18,7 +18,7 @@ The baseline (Claude Haiku 4.5, mean=5.8) is reused from exp3 to enable cross-ro
 | MiniMax M2.5 | OpenRouter | ~$0.02 |
 | DeepSeek V3.2 | OpenRouter | ~$0.01 |
 | Kimi K2.5 | OpenRouter | ~$0.03 |
-| Mistral Small 2603 | OpenRouter | ~$0.008 |
+| Mistral Small 4 | OpenRouter | ~$0.008 |
 
 ## Results
 
@@ -28,17 +28,17 @@ The baseline (Claude Haiku 4.5, mean=5.8) is reused from exp3 to enable cross-ro
 | MiniMax M2.5 | 5 | 6.4 | 0.0 | 0.524 | -0.32 | pass |
 | DeepSeek V3.2 | 3 | 1.0 | 0.4 | 0.036 | 1.0 | fail |
 | Kimi K2.5 | 5 | 6.6 | 0.0 | 0.238 | -0.48 | pass |
-| Mistral Small 2603 | 5 | 5.4 | 0.375 | 1.000 | 0.04 | fail |
+| Mistral Small 4 | 5 | 5.4 | 0.375 | 1.000 | 0.04 | fail |
 
 ## Key Finding
 
-Two of four candidates pass all gate criteria. Kimi K2.5 (mean=6.6) outperforms the baseline, demonstrating that higher-tier open-weight models can exceed Haiku 4.5 quality on SCOUT tasks. MiniMax M2.5 also passes. DeepSeek V3.2 and Mistral Small 2603 fail: DeepSeek exhibits infrastructure issues (40% error rate), while Mistral fails the minimum score gate (lowest run scored 4 vs required threshold 5) despite passing the mean gate (5.4 > 5.3).
+Two of four candidates pass all gate criteria. Kimi K2.5 (mean=6.6) outperforms the baseline, demonstrating that higher-tier open-weight models can exceed Haiku 4.5 quality on SCOUT tasks. MiniMax M2.5 also passes. DeepSeek V3.2 and Mistral Small 4 fail: DeepSeek exhibits infrastructure issues (40% error rate), while Mistral fails the minimum score gate (lowest run scored 4 vs required threshold 5) despite passing the mean gate (5.4 > 5.3).
 
 ## Session Gap Note
 
 Runs 27 and 30 are absent from the session directory. DeepSeek V3.2 produced no parseable JSON output on those two attempts (logged in `latency-log.jsonl`).
 
-Runs 36-40 (Mistral Small 2603) appear as separate batches in `sessions/`: runs 36-37 have longer time gaps between associated log entries and were executed in a separate session batch from runs 38-40.
+Runs 36-40 (Mistral Small 4) appear as separate batches in `sessions/`: runs 36-37 have longer time gaps between associated log entries and were executed in a separate session batch from runs 38-40.
 
 ## Documentation
 
@@ -48,7 +48,7 @@ Runs 36-40 (Mistral Small 2603) appear as separate batches in `sessions/`: runs 
 - **Scorer Prompt**: [scorer-prompt.md](scorer-prompt.md) — prompt template for rubric-based evaluation
 - **Analysis**: [analysis.json](analysis.json) — parsed scores with statistical summaries
 - **Scores**: [scores.json](scores.json) — raw run-level scores per criterion
-- **Scores (Mistral)**: [scores-mistral.json](scores-mistral.json) — raw run-level scores for Mistral Small 2603
+- **Scores (Mistral)**: [scores-mistral.json](scores-mistral.json) — raw run-level scores for Mistral Small 4
 - **Efficiency**: [efficiency.json](efficiency.json) — latency and token usage per run
 - **Label Map**: [label-map.json](label-map.json) — run_id to model name mapping (sealed before scoring; revealed after)
 - **Latency Log**: [latency-log.jsonl](latency-log.jsonl) — per-line timing data for all runs
@@ -64,7 +64,7 @@ This experiment uses the same 8-criterion rubric as exp3. See `rubric.md` in thi
 - `scout-run-26.json`: DeepSeek V3.2 (run 1 of 3)
 - `scout-run-28.json` through `scout-run-29.json`: DeepSeek V3.2 (runs 2-3, sparse)
 - `scout-run-31.json` through `scout-run-35.json`: Kimi K2.5
-- `scout-run-36.json` through `scout-run-40.json`: Mistral Small 2603
+- `scout-run-36.json` through `scout-run-40.json`: Mistral Small 4
 - Runs 27 and 30 (DeepSeek V3.2) are absent due to JSON parsing failures
 
 ## Methodology
@@ -73,4 +73,4 @@ See [METHODOLOGY.md](METHODOLOGY.md) for blinding protocol, rubric details, scor
 
 ## Latency Reconstruction Note
 
-Runs 36-37 (Mistral Small 2603) wall times are derived from sessions.db created_at timestamps rather than directly measured in latency-log.jsonl. Run 36 attempt 1 produced truncated output (4 tokens) requiring retry; run 37 attempt 2 completed successfully (381 tokens). Wall time values in efficiency.json reflect individual session durations, not cumulative retry overhead.
+Runs 36-37 (Mistral Small 4) wall times are derived from sessions.db created_at timestamps rather than directly measured in latency-log.jsonl. Run 36 attempt 1 produced truncated output (4 tokens) requiring retry; run 37 attempt 2 completed successfully (381 tokens). Wall time values in efficiency.json reflect individual session durations, not cumulative retry overhead.

--- a/experiments/exp5-role-evaluation/METHODOLOGY.md
+++ b/experiments/exp5-role-evaluation/METHODOLOGY.md
@@ -59,5 +59,5 @@ task (frontmatter patch confirmation). The two experiment series are complementa
 - exp3/exp4: which models can synthesize architectural proposals from a real codebase? (SCOUT)
 - exp5: which models can execute structured validation tasks reliably? (all other roles)
 
-Mistral Small 2603 fails the exp4 SCOUT bar and passes the exp5 validation bar. These findings
+Mistral Small 4 fails the exp4 SCOUT bar and passes the exp5 validation bar. These findings
 are consistent: the model is capable of structured read-and-verify tasks but not deep synthesis.

--- a/experiments/exp5-role-evaluation/README.md
+++ b/experiments/exp5-role-evaluation/README.md
@@ -13,7 +13,7 @@ exp3 and exp4 evaluated SCOUT delegate replacements only. This experiment extend
 and is not a replacement candidate; it is included here for completeness and as a methodological
 control.
 
-Exp4 result for Mistral Small 2603 on SCOUT: fail (mean=5.4, min=4, C3=0%, C5=0%, 37.5%
+Exp4 result for Mistral Small 4 on SCOUT: fail (mean=5.4, min=4, C3=0%, C5=0%, 37.5%
 hard-failure rate). That verdict is not revisited here.
 
 ## Method

--- a/experiments/exp5-role-evaluation/protocol.md
+++ b/experiments/exp5-role-evaluation/protocol.md
@@ -21,7 +21,7 @@ The worktree was already patched when delegates ran. SCOUT delegates therefore s
 | Model | OpenRouter string | Notes |
 |-------|-------------------|-------|
 | Claude Haiku 4.5 | `anthropic/claude-haiku-4.5` | Baseline; also used in exp3/exp4 |
-| Mistral Small 2603 | `mistralai/mistral-small-2603` | Candidate; failed SCOUT in exp4 |
+| Mistral Small 4 | `mistralai/mistral-small-2603` | Candidate; failed SCOUT in exp4 |
 | MiniMax M2.5 | `minimax/minimax-m2.5` | Passed exp4 SCOUT; included for comparison |
 
 ## Inference mode

--- a/experiments/exp6-mercury2-evaluation/README.md
+++ b/experiments/exp6-mercury2-evaluation/README.md
@@ -11,10 +11,10 @@ delegate roles without degrading output quality, and can it succeed as SCOUT whe
 Exp3 and exp4 evaluated SCOUT replacements using a tree-sitter synthesis task (n=5, C1-C8 rubric,
 blinded). Exp5 extended coverage to all 7 roles using a simpler frontmatter verification task
 (n=1 per role, binary correct/incorrect). This experiment applies exp4-style n=5 runs to the
-exp5 task, enabling statistical comparison with Mistral Small 2603's exp4 SCOUT score.
+exp5 task, enabling statistical comparison with Mistral Small 4's exp4 SCOUT score.
 
 Haiku 4.5 baseline: exp3/exp4 mean=5.8/8 (SCOUT, tree-sitter task).
-Mistral Small 2603: exp4 mean=5.4/8 (SCOUT, tree-sitter task, verdict=fail).
+Mistral Small 4: exp4 mean=5.4/8 (SCOUT, tree-sitter task, verdict=fail).
 Mercury 2: exp6 mean=4.6/8 (SCOUT, frontmatter task, this experiment).
 
 **Direct comparison caveat:** The exp6 SCOUT task differs from exp3/exp4. The rubric was adapted
@@ -91,7 +91,7 @@ not a model failure. Mercury 2 correctly reported FAIL when diff was empty.
 
 Pricing: $0.25/M input, $0.75/M output (OpenRouter, 2026-03-28).
 
-### Comparison with Haiku 4.5 and Mistral Small 2603 (exp5 data, n=1)
+### Comparison with Haiku 4.5 and Mistral Small 4 (exp5 data, n=1)
 
 | Model | SCOUT wall (s) | Pipeline wall (s) | Pipeline cost ($) | GUARD pass | BUILD pass |
 |-------|---------------|-------------------|-------------------|------------|------------|


### PR DESCRIPTION
## Summary

Mistral Small 4 is the official product name per [Mistral docs](https://docs.mistral.ai/models/mistral-small-4-0-26-03). \`mistral-small-2603\` is the API model path. Using "Mistral Small 2603" in prose was confusing to readers unfamiliar with the naming convention.

## Changes

- \`README.md\`: all prose occurrences updated
- \`METHODOLOGY.md\`: updated; bold entry now reads \`Mistral Small 4 (mistral-small-2603)\` to preserve traceability
- \`experiments/exp4-model-comparison-r2/README.md\`: updated
- \`experiments/exp4-model-comparison-r2/METHODOLOGY.md\`: updated, section header renamed
- \`experiments/exp5-role-evaluation/README.md\`: updated
- \`experiments/exp5-role-evaluation/METHODOLOGY.md\`: updated
- \`experiments/exp5-role-evaluation/protocol.md\`: display name column updated; model path column unchanged
- \`experiments/exp6-mercury2-evaluation/README.md\`: updated

JSON files, label maps, and \`.worktrees/\` are unchanged.

## Test plan

- [ ] No remaining "Mistral Small 2603" in canonical prose files