### PR TITLE
docs: fix zenodo badge to use version DOI

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # llm-agent-experiments
 
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.19056876.svg)](https://doi.org/10.5281/zenodo.19056876)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.19056877.svg)](https://doi.org/10.5281/zenodo.19056877)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Sessions](https://img.shields.io/badge/sessions-89-green)](experiments/)
 [![Runs](https://img.shields.io/badge/runs-89-blue)](experiments/)


### PR DESCRIPTION
## Summary

The Zenodo shield badge was using the concept DOI (`zenodo.19056876`) instead of the version record DOI (`zenodo.19056877`). The concept DOI badge renders the raw DOI string as its label rather than a clean version identifier, making it look broken.

- `README.md`: replace `19056876` with `19056877` in both the SVG URL and the href on the badge line

## Pre-registration Checklist (experiment PRs only)

N/A - documentation fix only

## Data Integrity

N/A - no JSON data files changed

## Commit

- [x] GPG signed: `git log --show-signature -1`
- [x] DCO sign-off: `Signed-off-by:` present in commit message