### PR TITLE
fix(zenodo): add code:codeRepository to custom metadata

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -19,5 +19,8 @@
     }
   ],
   "keywords": ["ai-agents", "llm-evaluation", "benchmarking", "open-weight-models", "supplementary-materials"],
-  "publication_date": "2025-12-24"
+  "publication_date": "2025-12-24",
+  "custom": {
+    "code:codeRepository": "https://github.com/clouatre-labs/llm-agent-experiments"
+  }
 }


### PR DESCRIPTION
## Summary

Adds the missing `custom.code:codeRepository` field to `.zenodo.json`.

This field was already present on the live Zenodo record but absent from the on-disk config, meaning a new release would drop the repository URL from the metadata.

## Changes

- `.zenodo.json`: add `custom.code:codeRepository`

## Test plan

- [ ] Verify next Zenodo release includes the repository URL automatically