### PR TITLE
docs: correct DOI badge to all-versions DOI

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # llm-agent-experiments
 
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.19056877.svg)](https://doi.org/10.5281/zenodo.19056877)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.19056876.svg)](https://doi.org/10.5281/zenodo.19056876)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Sessions](https://img.shields.io/badge/sessions-89-green)](experiments/)
 [![Runs](https://img.shields.io/badge/runs-89-blue)](experiments/)


### PR DESCRIPTION
Correct the DOI badge from the version-specific DOI (`10.5281/zenodo.19056877`) to the all-versions DOI (`10.5281/zenodo.19056876`). The badge and link now match the BibTeX block already present in the README.
