### PR TITLE
docs: fix citation metadata and use concept DOI

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,13 +1,15 @@
 {
-  "title": "Orchestrating AI Agents: A Subagent Architecture -- Supplementary Data",
-  "description": "Pre-registered model comparison experiments (exp3, exp4) evaluating open-weight LLM coding agents as SCOUT delegates in the goose-coder recipe. Blind scoring with Mann-Whitney U statistical test.",
+  "title": "LLM Coding Agent Experiments",
+  "description": "Session logs, scoring rubrics, and analysis outputs from pre-registered model comparison experiments (exp3, exp4) evaluating open-weight LLM coding agents as SCOUT delegates in the goose-coder recipe. Data include per-run structured delegate outputs (JSON), blind scorer justifications, group assignment maps, and token/timing metadata.",
   "upload_type": "dataset",
   "access_right": "open",
   "license": "Apache-2.0",
   "version": "1.0.0",
+  "publication_date": "2025-12-24",
   "creators": [
     {
-      "name": "Clouatre, Hugues",
+      "name": "Clouâtre, Hugues",
+      "affiliation": "HEC Montréal",
       "orcid": "0009-0002-4291-1999"
     }
   ],
@@ -19,7 +21,6 @@
     }
   ],
   "keywords": ["ai-agents", "llm-evaluation", "benchmarking", "open-weight-models", "supplementary-materials"],
-  "publication_date": "2025-12-24",
   "custom": {
     "code:codeRepository": "https://github.com/clouatre-labs/llm-agent-experiments"
   }

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,9 +1,9 @@
 cff-version: 1.2.0
 message: "If you use this dataset, please cite the article from preferred-citation and the dataset itself."
 type: dataset
-title: "Orchestrating AI Agents: A Subagent Architecture"
+title: "LLM Coding Agent Experiments"
 authors:
-  - family-names: Clouatre
+  - family-names: Clouâtre
     given-names: Hugues
     orcid: "https://orcid.org/0009-0002-4291-1999"
 repository-code: https://github.com/clouatre-labs/llm-agent-experiments
@@ -12,13 +12,15 @@ license: Apache-2.0
 date-released: "2025-12-24"
 identifiers:
   - type: doi
-    value: 10.5281/zenodo.19056877
+    value: 10.5281/zenodo.19056876
     description: Zenodo DOI
 version: "1.0.0"
 abstract: >
-  Benchmarking open-weight LLM coding agents as SCOUT delegates in the
-  goose-coder recipe. Contains pre-registered protocols, blind scoring data,
-  and full session files for two model comparison experiments (exp3, exp4).
+  Session logs, scoring rubrics, and analysis outputs from pre-registered model
+  comparison experiments (exp3, exp4) evaluating open-weight LLM coding agents
+  as SCOUT delegates in the goose-coder recipe. Data include per-run structured
+  delegate outputs (JSON), blind scorer justifications, group assignment maps,
+  and token/timing metadata.
 keywords:
   - ai-agents
   - llm-evaluation
@@ -27,7 +29,7 @@ keywords:
   - supplementary-materials
 preferred-citation:
   authors:
-    - family-names: Clouatre
+    - family-names: Clouâtre
       given-names: Hugues
       orcid: "https://orcid.org/0009-0002-4291-1999"
   title: "Orchestrating AI Agents: A Subagent Architecture"

--- a/README.md
+++ b/README.md
@@ -261,8 +261,8 @@ If you use this dataset or methodology, please cite:
 
 ```bibtex
 @misc{clouatre2026orchestrating,
-  title   = {Orchestrating AI Agents: A Subagent Architecture},
-  author  = {Clouatre, Hugues},
+  title   = {LLM Coding Agent Experiments},
+  author  = {Clouâtre, Hugues},
   year    = {2026},
   doi     = {10.5281/zenodo.19056876},
   howpublished = {\url{https://clouatre.ca/posts/orchestrating-ai-agents-subagent-architecture/}},


### PR DESCRIPTION
## Summary

Aligns citation metadata with Zenodo record and dataset best practices.

## Changes

- `CITATION.cff`: accent fix, title update, concept DOI, abstract cleaned
- `.zenodo.json`: accent fix, title update, affiliation added, description cleaned
- `README.md`: bibtex title and author accent fixed

## Concept DOI

`10.5281/zenodo.19056876` (was version DOI `10.5281/zenodo.19056877`)
