### PR TITLE
chore: add .github/aptu.yml to enable aptu triage and review

### DIFF
--- a/.github/aptu.yml
+++ b/.github/aptu.yml
@@ -1,0 +1,6 @@
+version: 1
+triage:
+  enabled: true
+review:
+  enabled: true
+  instructions-file: .github/instructions/pr-review.md

--- a/.github/instructions/pr-review.md
+++ b/.github/instructions/pr-review.md
@@ -1,0 +1,12 @@
+# PR Review Instructions
+
+## Scope
+
+Review only what the PR changes. Do not flag issues in files the PR does not touch.
+
+## General
+
+- Flag logic errors, correctness issues, and security concerns.
+- Do not flag style or formatting issues enforced by CI.
+- One comment per distinct issue.
+- Prefer a suggestion block over describing the problem when the fix is unambiguous.


### PR DESCRIPTION
Add `.github/aptu.yml` to opt this repository into aptu automated issue triage and PR review via the aptu-github-app webhook.

The worker dispatches only when this file is present with `enabled: true` -- no file means no dispatch.