### PR TITLE
feat(exp9): add openrouter evaluation r2 with corrected prompt, C4, and C8

### DIFF
--- a/experiments/exp9-openrouter-evaluation-r2/README.md
+++ b/experiments/exp9-openrouter-evaluation-r2/README.md
@@ -1,0 +1,72 @@
+# Experiment 9: OpenRouter Model Evaluation (Round 2)
+
+Replicates Experiment 8 on a new task (aptu#1205: multi-forge support) with three fixes: corrected runner prompt, broadened C4 heuristic, and proper C8 JSON validation.
+
+## Research Question
+
+When routing all three models through a single OpenRouter endpoint, does the ranking (Gemma 4 vs Haiku 4.5 vs Sonnet 4.6) replicate across tasks, or are the exp8 results task-specific?
+
+## Models
+
+| Model | API | Run IDs | Price/M input | Price/M output |
+|-------|-----|---------|---------------|----------------|
+| Google Gemma 4 26B-A4B | OpenRouter | run-86 to run-95 | $0.06 | $0.33 |
+| Claude Haiku 4.5 | OpenRouter | run-96 to run-105 | $1.00 | $5.00 |
+| Claude Sonnet 4.6 | OpenRouter | run-106 to run-115 | $3.00 | $15.00 |
+
+## Run Configuration
+
+| Config | Value |
+|--------|-------|
+| Total runs | 30 (10 per model) |
+| Pilot runs | run-86 (gemma4), run-96 (haiku45), run-106 (sonnet46) |
+| Endpoint | OpenRouter (https://openrouter.ai/api/v1) |
+| Task | SCOUT research on clouatre-labs/aptu#1205 |
+| Max tokens | 4096 |
+| Temperature | 0.5 |
+
+## Outputs
+
+| File | Description |
+|------|-------------|
+| `sessions/run-NN.json` | Raw model output (response text, tokens, latency, cost) |
+| `results/latency.jsonl` | Per-run latency log |
+| `results/cost_summary.json` | Aggregated cost per model |
+| `results/scores.jsonl` | Blind C1-C8 scores per run |
+| `label-map.json` | Run ID to model key mapping (sealed before runs) |
+| `runner-prompt.md` | Task prompt sent to each model |
+| `rubric.md` | Scoring rubric (C1-C8) |
+| `scorer-prompt.md` | Instructions for the blind scorer |
+
+## Gate Criteria
+
+Same as exp8:
+
+- Mean score >= 5.3/8 (67%)
+- Minimum score >= 5/8
+- Error rate <= 0.2 (2/10 failures)
+- Mann-Whitney U test p >= 0.05 between consecutive models
+
+## Amendments vs exp8
+
+Three fixes applied:
+
+1. **Corrected runner prompt.** exp8 used the raw bash-escaped SCOUT_INSTRUCTIONS variable (\\n literals) from exp3's runner-prompt.md. exp9 properly unescapes into real newlines via the `runner-prompt.md` extraction logic.
+2. **Broadened C4 heuristic.** Old C4 checked for `#735`, `#736`, `#737`, `issue`, `pr`. New C4 checks for `#1205` OR (multi-forge domain keywords AND structural code keywords).
+3. **Proper C8 JSON validation.** Old C8 returned 1 unconditionally. New C8 parses the response text as JSON and validates all 11 required handoff schema fields.
+
+## Usage
+
+```bash
+# Pilot run (one per model)
+uv run python run_inference.py --pilot
+
+# Full run
+uv run python run_inference.py
+
+# Score
+uv run python score.py
+
+# Score with model labels revealed
+uv run python score.py --reveal
+```

--- a/experiments/exp9-openrouter-evaluation-r2/pyproject.toml
+++ b/experiments/exp9-openrouter-evaluation-r2/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+name = "exp9-openrouter-evaluation-r2"
+version = "0.1.0"
+requires-python = ">=3.13"
+dependencies = [
+    "openai>=1.0.0",
+    "ruff>=0.9.0",
+]

--- a/experiments/exp9-openrouter-evaluation-r2/rubric.md
+++ b/experiments/exp9-openrouter-evaluation-r2/rubric.md
@@ -1,0 +1,144 @@
+# Experiment 9: Scoring Rubric
+
+Scoring criteria for the SCOUT research task on clouatre-labs/aptu#1205 (feat(core): multi-forge support for GitLab, Gitea/Forgejo, and Azure DevOps).
+
+## Criteria
+
+### C1: Forge module implementation files identified
+
+**Criterion:** Delegate identifies the correct files related to forge/provider implementation in the aptu codebase.
+
+**Ground truth:** The forge module lives under `crates/aptu-core/src/forge/` and includes provider implementations (GitHub provider, etc.), trait definitions, and auth modules. Acceptable files include `crates/aptu-core/src/forge.rs`, `crates/aptu-core/src/forge/*.rs`, provider files, and related trait definitions.
+
+**Scoring:** 1 if delegate names at least one specific forge-related file and verifies it exists in the repo. 0 if delegate speaks generically about "the forge module" without naming a file.
+
+**Rationale:** Ensures delegate actually navigated the codebase rather than relying on parametric knowledge.
+
+---
+
+### C2: Provider trait pattern understood
+
+**Criterion:** Delegate demonstrates understanding of how forge providers are implemented -- the trait pattern, provider registration, and dispatch.
+
+**Ground truth:** The forge module uses a trait-based design (e.g., `ForgeProvider` trait) with individual provider structs implementing the trait. The delegate should reference `impl ... for Github`, provider registration, or dispatch logic.
+
+**Scoring:** 1 if delegate references specific provider trait/struct/enum patterns with codebase evidence. 0 if delegate speaks in generalities without evidence.
+
+**Rationale:** Demonstrates code comprehension at the implementation level.
+
+---
+
+### C3: Test coverage for existing forge providers noted
+
+**Criterion:** Delegate identifies at least one relevant test file or test function for forge providers.
+
+**Ground truth:** Look for test files in `crates/aptu-core/tests/` or `crates/aptu-core/src/forge/` with tests exercising provider behaviors.
+
+**Scoring:** 1 if delegate names a test file or test function related to forge/provider functionality. 0 if no test references.
+
+**Rationale:** Tests are critical for safely extending provider support.
+
+---
+
+### C4: Multi-forge architecture references
+
+**Criterion:** Delegate identifies issue #1205 or references multi-forge architecture concerns (forge domain concepts, provider abstraction patterns).
+
+**Ground truth:** The issue is about adding support for GitLab, Gitea/Forgejo, and Azure DevOps as forge providers. Acceptable references include the issue number (#1205) or domain-specific terms like 'forge', 'gitlab', 'gitea', 'forgejo', 'azure devops', 'multi-forge', combined with structural references like 'trait', 'aptu-core', 'impl', 'backend', 'provider'.
+
+**Scoring:** 1 if delegate references #1205 directly OR references multi-forge domain terms combined with structural code terms. 0 if delegate makes no connection to multi-forge architecture.
+
+**Rationale:** Ensures delegate engaged with the specific issue's domain and considered architectural implications.
+
+---
+
+### C5: Provider-specific patterns identified
+
+**Criterion:** Delegate identifies at least 2 specific patterns or approaches that differ across forge providers (GitLab vs GitHub vs Gitea/Forgejo vs Azure DevOps).
+
+**Ground truth:** Different forges have different API patterns: GitLab uses project IDs vs GitHub uses owner/repo, Azure DevOps uses organization/project/repo paths, Gitea/Forgejo use similar patterns to GitHub but with different API endpoints, auth mechanisms differ (personal access tokens vs OAuth vs Azure AD).
+
+**Scoring:** 1 if delegate identifies at least 2 specific provider-specific differences with codebase evidence or API comparison. 0 if delegate treats all providers as identical or mentions only generic patterns.
+
+**Rationale:** Demonstrates understanding that providers are not drop-in replacements.
+
+---
+
+### C6: Auth flow differences noted
+
+**Criterion:** Delegate identifies that different forge providers have different authentication mechanisms and notes the implications for the existing auth code.
+
+**Ground truth:** GitHub uses personal access tokens (classic and fine-grained), GitLab uses personal/project/group access tokens, Azure DevOps uses Azure AD / PAT, Gitea/Forgejo use their own token types. The existing auth code may need to be extended or abstracted.
+
+**Scoring:** 1 if delegate makes an explicit statement about auth flow differences across providers and how they impact the codebase. 0 if auth is not mentioned or is dismissed as trivial.
+
+**Rationale:** Auth is often the most complex part of multi-provider support. Demonstrates architectural maturity.
+
+---
+
+### C7: Non-obvious architectural implication requiring code synthesis
+
+**Criterion:** Delegate identifies a non-obvious architectural implication that requires reading and synthesizing code, not just summarizing the issue.
+
+**Ground truth:** Examples of acceptable responses:
+- Recognizing that the existing `ForgeProvider` trait may need new methods (e.g., for repo discovery, webhook management) that not all providers can implement
+- Identifying that provider-specific URL parsing (SSH vs HTTPS, different path formats) requires a new abstraction layer
+- Noting that rate-limiting and API versioning differ per provider and proposing a strategy
+- Recognizing that existing tests that mock GitHub will not port directly to other providers
+- Identifying that CI/CD integrations (GitHub Actions vs GitLab CI vs Azure Pipelines) may require separate handling
+
+**Scoring:** 1 if delegate identifies at least one non-obvious implication that requires synthesis beyond the issue text. 0 if all points are direct summaries of the issue or generic advice.
+
+**Rationale:** Prevents ceiling effect. Requires delegate to think beyond the issue description.
+
+---
+
+### C8: Valid JSON output per handoff schema
+
+**Criterion:** Delegate produces a valid JSON file matching the handoff schema specified in the orchestration instructions.
+
+**Ground truth:** Output file must be valid JSON (parseable by `jq`), must contain required fields per the SCOUT handoff schema: `session_id`, `lens`, `relevant_files`, `conventions`, `patterns`, `related_issues`, `constraints`, `test_coverage`, `library_findings`, `approaches`, `recommendation`. Must not contain syntax errors.
+
+**Scoring:** 1 if output file is valid JSON and contains all required fields per the handoff schema. 0 if file is missing, is not valid JSON, or is missing required fields.
+
+**Rationale:** Ensures delegate followed instructions and produced machine-readable output. Non-negotiable for downstream processing.
+
+---
+
+## Scoring Procedure
+
+1. **Scorer receives:** 30 run files (`run-86.json` through `run-115.json`), this rubric, and no other metadata
+2. **Scorer does not receive:** `label-map.json`, model names, run order, or any information that would reveal which model produced which run
+3. **For each run:** Score each criterion independently (1 or 0)
+4. **Total score:** Sum of all 8 criteria (0-8)
+5. **Output:** Write `scores.jsonl` with run ID, individual criterion scores, total score, and brief justification for each criterion
+6. **After scoring:** Orchestrator reveals `label-map.json` and computes group statistics
+
+---
+
+## Justification Format
+
+For each criterion, scorer provides a brief justification (1-2 sentences) explaining why the criterion was met or not met. Examples:
+
+- **C1 met:** "Delegate explicitly names `crates/aptu-core/src/forge.rs` and verifies it exists in the repo."
+- **C1 not met:** "Delegate mentions 'the forge module' but does not name a specific file or verify its location."
+- **C7 met:** "Delegate recognizes that provider-specific URL parsing requires a new abstraction layer and proposes concrete handling strategy."
+- **C7 not met:** "Delegate summarizes the issue but does not propose any non-obvious architectural implications."
+
+---
+
+## Amendments vs exp8
+
+Compared to Experiment 8 rubric (which was adapted from exp3), this rubric makes three changes:
+
+1. **Domain shift:** All criteria now reference forge/multi-forge architecture (Issue #1205) instead of SecurityScanner/tree-sitter (Issue #737).
+2. **C4 broadened:** Issue reference OR multi-forge domain keywords combined with structural code keywords, instead of old #735/#736/#737 check.
+3. **C8 unchanged:** Same handoff schema validation (11 required JSON fields).
+
+---
+
+## References
+
+- Target issue: https://github.com/clouatre-labs/aptu/issues/1205
+- Forge module context: `crates/aptu-core/src/forge.rs`, provider implementations in `crates/aptu-core/src/forge/`
+- Experiment 8 rubric: `experiments/exp8-openrouter-evaluation/`

--- a/experiments/exp9-openrouter-evaluation-r2/run_inference.py
+++ b/experiments/exp9-openrouter-evaluation-r2/run_inference.py
@@ -1,0 +1,418 @@
+"""
+run_inference.py -- Experiment 9: OpenRouter Model Evaluation (Round 2)
+
+Runs Gemma 4 26B-A4B, Claude Haiku 4.5, and Claude Sonnet 4.6 through
+a single OpenRouter endpoint (base_url=https://openrouter.ai/api/v1) on
+the exp9 runner prompt (adapted from exp3 SCOUT instructions for #1205).
+
+## Auth
+
+API key from OPENROUTER_API_KEY environment variable.
+OpenRouter base URL: https://openrouter.ai/api/v1
+
+## Usage
+
+  uv run python run_inference.py [--dry-run] [--model MODEL_KEY] [--runs N] [--pilot]
+
+  --dry-run   Print config and exit; no API calls
+  --model     One of: gemma4, haiku45, sonnet46 (default: all)
+  --runs      Number of runs per model (default: 10)
+  --pilot     Run only one run per model (run-86, run-96, run-106) and exit
+"""
+
+import argparse
+import json
+import os
+import pathlib
+import random
+import sys
+import time
+from datetime import UTC, datetime
+
+import openai
+
+# --- Model Configuration ---
+
+MODEL_CONFIGS = {
+    "gemma4": {
+        "model_id": "google/gemma-4-26b-a4b-it",
+        "run_ids": [
+            "run-86",
+            "run-87",
+            "run-88",
+            "run-89",
+            "run-90",
+            "run-91",
+            "run-92",
+            "run-93",
+            "run-94",
+            "run-95",
+        ],
+        "input_price_per_mtok": 0.06,
+        "output_price_per_mtok": 0.33,
+    },
+    "haiku45": {
+        "model_id": "anthropic/claude-haiku-4.5",
+        "run_ids": [
+            "run-96",
+            "run-97",
+            "run-98",
+            "run-99",
+            "run-100",
+            "run-101",
+            "run-102",
+            "run-103",
+            "run-104",
+            "run-105",
+        ],
+        "input_price_per_mtok": 1.00,
+        "output_price_per_mtok": 5.00,
+    },
+    "sonnet46": {
+        "model_id": "anthropic/claude-sonnet-4.6",
+        "run_ids": [
+            "run-106",
+            "run-107",
+            "run-108",
+            "run-109",
+            "run-110",
+            "run-111",
+            "run-112",
+            "run-113",
+            "run-114",
+            "run-115",
+        ],
+        "input_price_per_mtok": 3.00,
+        "output_price_per_mtok": 15.00,
+    },
+}
+
+EXP9_DIR = pathlib.Path(__file__).parent.resolve()
+RESULTS_DIR = EXP9_DIR / "results"
+SESSIONS_DIR = EXP9_DIR / "sessions"
+LABEL_MAP_PATH = EXP9_DIR / "label-map.json"
+RUNNER_PROMPT_PATH = EXP9_DIR / "runner-prompt.md"
+
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+
+PILOT_RUN_IDS = {
+    "gemma4": "run-86",
+    "haiku45": "run-96",
+    "sonnet46": "run-106",
+}
+
+
+def build_client() -> openai.OpenAI:
+    """Return an OpenAI client routed through OpenRouter."""
+    api_key = os.environ.get("OPENROUTER_API_KEY")
+    if not api_key:
+        raise ValueError("OPENROUTER_API_KEY environment variable is required")
+    return openai.OpenAI(
+        base_url=OPENROUTER_BASE_URL,
+        api_key=api_key,
+    )
+
+
+def read_runner_prompt() -> str:
+    """Read the exp9 runner prompt."""
+    if not RUNNER_PROMPT_PATH.exists():
+        raise FileNotFoundError(
+            f"Runner prompt not found: {RUNNER_PROMPT_PATH.resolve()}"
+        )
+    return RUNNER_PROMPT_PATH.read_text(encoding="utf-8")
+
+
+def compute_cost_usd(input_tokens: int, output_tokens: int, config: dict) -> float:
+    """Compute cost in USD based on token counts and model pricing."""
+    input_cost = (input_tokens / 1_000_000) * config["input_price_per_mtok"]
+    output_cost = (output_tokens / 1_000_000) * config["output_price_per_mtok"]
+    return round(input_cost + output_cost, 10)
+
+
+def run_single(
+    run_id: str,
+    model_key: str,
+    prompt: str,
+    client: openai.OpenAI,
+    dry_run: bool,
+    sessions_dir: pathlib.Path,
+) -> dict:
+    """Run inference via OpenRouter endpoint using the OpenAI SDK.
+
+    Interpolates RUN_ID and OUTPUT_PATH placeholders into the prompt
+    before sending.
+    """
+    config = MODEL_CONFIGS[model_key]
+    model_id = config["model_id"]
+
+    # Interpolate placeholders
+    output_path = str(sessions_dir / f"{run_id}.json")
+    interpolated_prompt = prompt.replace("RUN_ID", run_id).replace(
+        "OUTPUT_PATH", output_path
+    )
+
+    if dry_run:
+        return {
+            "run_id": run_id,
+            "model_id": model_id,
+            "model_key": model_key,
+            "response_text": "[dry-run]",
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "latency_ms": 0,
+            "cost_usd": 0.0,
+            "timestamp_utc": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        }
+
+    start = time.monotonic()
+
+    max_retries = 3
+    for attempt in range(max_retries + 1):
+        try:
+            response = client.chat.completions.create(
+                model=model_id,
+                messages=[{"role": "user", "content": interpolated_prompt}],
+                max_tokens=4096,
+                temperature=0.5,
+            )
+            break
+        except openai.RateLimitError as e:
+            if attempt < max_retries:
+                delay = (2 ** (attempt + 1)) + random.random()
+                print(
+                    f"  Rate limited, retrying in {delay:.1f}s "
+                    f"(attempt {attempt + 1}/{max_retries})",
+                    file=sys.stderr,
+                )
+                time.sleep(delay)
+            else:
+                raise e
+
+    latency_ms = int((time.monotonic() - start) * 1000)
+    output_text = response.choices[0].message.content or ""
+    input_tokens = response.usage.prompt_tokens if response.usage else 0
+    output_tokens = response.usage.completion_tokens if response.usage else 0
+    cost_usd = compute_cost_usd(input_tokens, output_tokens, config)
+
+    return {
+        "run_id": run_id,
+        "model_id": model_id,
+        "model_key": model_key,
+        "response_text": output_text,
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "latency_ms": latency_ms,
+        "cost_usd": cost_usd,
+        "timestamp_utc": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+
+
+def write_label_map():
+    """Write label-map.json mapping all run IDs to model keys."""
+    label_map = {}
+    for model_key, config in MODEL_CONFIGS.items():
+        for run_id in config["run_ids"]:
+            label_map[run_id] = model_key
+    LABEL_MAP_PATH.write_text(
+        json.dumps(label_map, separators=(",", ":")), encoding="utf-8"
+    )
+    print(f"Wrote label map ({len(label_map)} entries) to {LABEL_MAP_PATH}")
+
+
+def write_session(result: dict):
+    """Write a single session file to sessions/."""
+    run_id = result["run_id"]
+    output_path = SESSIONS_DIR / f"{run_id}.json"
+    output_path.write_text(json.dumps(result, indent=2, default=str), encoding="utf-8")
+    print(f"  Wrote {output_path}")
+
+
+def append_latency_log(result: dict):
+    """Append a latency entry to results/latency.jsonl."""
+    latency_entry = {
+        "run_id": result["run_id"],
+        "model_id": result["model_id"],
+        "model_key": result["model_key"],
+        "latency_ms": result["latency_ms"],
+        "input_tokens": result["input_tokens"],
+        "output_tokens": result["output_tokens"],
+        "cost_usd": result["cost_usd"],
+        "timestamp_utc": result["timestamp_utc"],
+    }
+    latency_log_path = RESULTS_DIR / "latency.jsonl"
+    with open(latency_log_path, "a", encoding="utf-8") as f:
+        f.write(json.dumps(latency_entry, separators=(",", ":")) + "\n")
+
+
+def write_cost_summary(results: list[dict]):
+    """Write results/cost_summary.json after all runs."""
+    summary = {}
+    for r in results:
+        mk = r["model_key"]
+        if mk not in summary:
+            summary[mk] = {
+                "model_key": mk,
+                "model_id": r["model_id"],
+                "n_runs": 0,
+                "total_cost_usd": 0.0,
+                "total_input_tokens": 0,
+                "total_output_tokens": 0,
+                "runs": [],
+            }
+        s = summary[mk]
+        s["n_runs"] += 1
+        s["total_cost_usd"] += r.get("cost_usd") or 0.0
+        s["total_input_tokens"] += r.get("input_tokens") or 0
+        s["total_output_tokens"] += r.get("output_tokens") or 0
+        latency = r.get("latency_ms")
+        cost = r.get("cost_usd")
+        s["runs"].append(
+            {
+                "run_id": r["run_id"],
+                "latency_ms": latency,
+                "cost_usd": cost,
+            }
+        )
+
+    for mk in summary:
+        s = summary[mk]
+        s["mean_cost_usd"] = round(s["total_cost_usd"] / s["n_runs"], 10)
+
+    cost_summary_path = RESULTS_DIR / "cost_summary.json"
+    cost_summary_path.write_text(
+        json.dumps(summary, indent=2, default=str), encoding="utf-8"
+    )
+    print(f"Wrote cost summary to {cost_summary_path}")
+
+
+def print_dry_run():
+    """Print configuration and exit without making API calls."""
+    print(f"{'=' * 60}")
+    print("Experiment 9: OpenRouter Model Evaluation (Round 2) (DRY RUN)")
+    print(f"{'=' * 60}")
+
+    for model_key, config in MODEL_CONFIGS.items():
+        print(f"\nModel: {model_key}")
+        print(f"  Model ID:        {config['model_id']}")
+        print(f"  Run IDs:         {', '.join(config['run_ids'])}")
+        print(
+            f"  Pricing:         "
+            f"${config['input_price_per_mtok']}/M input, "
+            f"${config['output_price_per_mtok']}/M output"
+        )
+
+    print(f"\n{'=' * 60}")
+    print("No API calls were made.")
+    sys.exit(0)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run inference for Experiment 9")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print config and exit; no API calls",
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        choices=list(MODEL_CONFIGS.keys()),
+        default=None,
+        help="Model to run (default: all)",
+    )
+    parser.add_argument(
+        "--runs",
+        type=int,
+        default=10,
+        help="Number of runs per model (default: 10)",
+    )
+    parser.add_argument(
+        "--pilot",
+        action="store_true",
+        help="Run only one run per model (run-86, run-96, run-106) and exit",
+    )
+    args = parser.parse_args()
+
+    if args.dry_run:
+        print_dry_run()
+
+    if args.pilot:
+        args.runs = 1
+
+    # Ensure directories exist
+    SESSIONS_DIR.mkdir(parents=True, exist_ok=True)
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+
+    # Write label map before any API calls
+    write_label_map()
+
+    # Read the runner prompt
+    prompt = read_runner_prompt()
+
+    # Build client once; reuse across all runs
+    client = build_client()
+
+    # Determine which models to run
+    model_keys = [args.model] if args.model else list(MODEL_CONFIGS.keys())
+
+    all_results = []
+
+    for model_key in model_keys:
+        config = MODEL_CONFIGS[model_key]
+        print(f"\n--- Running {model_key} ({config['model_id']}) ---")
+
+        if args.pilot:
+            run_ids = [PILOT_RUN_IDS[model_key]]
+        else:
+            run_ids = config["run_ids"][: args.runs]
+
+        for run_id in run_ids:
+            print(f"  Starting {run_id}...")
+            try:
+                result = run_single(
+                    run_id,
+                    model_key,
+                    prompt,
+                    client,
+                    dry_run=False,
+                    sessions_dir=SESSIONS_DIR,
+                )
+                write_session(result)
+                append_latency_log(result)
+                all_results.append(result)
+                print(
+                    f"  Done: {run_id} | "
+                    f"latency={result['latency_ms']}ms | "
+                    f"cost=${result['cost_usd']} | "
+                    f"tokens={result['input_tokens']}+{result['output_tokens']}"
+                )
+            except Exception as e:
+                error_result = {
+                    "run_id": run_id,
+                    "model_id": config["model_id"],
+                    "model_key": model_key,
+                    "error": str(e),
+                    "latency_ms": None,
+                    "cost_usd": None,
+                    "timestamp_utc": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                }
+                write_session(error_result)
+                all_results.append(error_result)
+                print(f"  ERROR: {run_id} -- {e}")
+
+        if args.pilot:
+            break
+
+    # Write cost summary after all runs
+    write_cost_summary(all_results)
+
+    print(f"\n{'=' * 60}")
+    print("Inference complete.")
+    print(f"Session files: {SESSIONS_DIR}")
+    print(f"Latency log:   {RESULTS_DIR / 'latency.jsonl'}")
+    print(f"Cost summary:  {RESULTS_DIR / 'cost_summary.json'}")
+    print(f"{'=' * 60}")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/exp9-openrouter-evaluation-r2/runner-prompt.md
+++ b/experiments/exp9-openrouter-evaluation-r2/runner-prompt.md
@@ -1,0 +1,77 @@
+# SCOUT Research Agent (READ-ONLY)
+
+You are the SCOUT -- a creative explorer. Your job is to deeply understand the codebase, research the ecosystem, and propose 2-3 solution approaches for a specific issue. You cast a wide net.
+
+## Target
+- Repository: clouatre-labs/aptu
+- Issue: #1205 (feat(core): multi-forge support for GitLab, Gitea/Forgejo, and Azure DevOps)
+- Clone the repo to a temp directory and work there
+
+## Constraint
+READ-ONLY. No code changes, no commits. Only write your output JSON to the path specified below.
+
+## Rules
+1. Clone clouatre-labs/aptu to a temp directory and cd into it
+2. No emojis in output
+3. Concise: Lead with summary, use bullets
+4. Efficiency: Chain shell commands with && to reduce turns
+5. Efficiency: Use rg with multiple patterns in one call
+6. Efficiency: Limit Context7 lookups to 2 libraries max
+7. Tool priority for research: (1) gh CLI for issues, PRs, repo metadata, cross-repo search; (2) Context7 for library docs and APIs; (3) brave_search as last resort for cross-project design rationale or blog posts (max 2 queries)
+
+## Step 1: Repo Structure
+- Read README, CONTRIBUTING.md, Cargo.toml
+- Identify project layout and module organization
+- Note build system, CI configuration
+
+## Step 2: Conventions
+- Commit style (conventional commits, signed, DCO)
+- Testing patterns (unit, integration, test location)
+- Linting and formatting tools
+- Error handling patterns
+- Import/module organization
+
+## Step 3: Relevant Code Analysis
+- Identify files related to the SecurityScanner and pattern matching with rg
+- Trace call chains and dependencies
+- Review similar patterns already in the project
+- Note test coverage for affected areas
+
+## Step 4: Ecosystem Research
+- From the imports and manifest files found in Steps 1-3, identify the 2-3 libraries most relevant to the problem (tree-sitter, tree-sitter-rust, etc.)
+- Use Context7 to research those specific libraries: current APIs, idioms, deprecations, migration guides
+- Before proposing any approach that uses a specific API or method, verify it exists in the installed version via Context7, type definitions, or package source. Do not rely on parametric knowledge for API surface claims.
+- Search for how similar projects solve this problem (prefer gh search repos or gh search code over brave_search)
+
+## Step 5: Issue and PR Context
+- Read the issue thread for context and discussion
+- Check linked PRs or related issues (#735, PR #736)
+- Note any maintainer preferences expressed in comments
+
+## Step 6: Propose Approaches
+- Identify 2-3 solution approaches
+- For each: describe changes, list pros/cons, estimate complexity
+- Be creative -- include the elegant solution even if it touches more files
+
+## Output
+Write your output as a JSON file to OUTPUT_PATH (compact: | jq -c .), then present a summary.
+
+The JSON must contain ALL of these fields:
+{
+  \"session_id\": \"RUN_ID\",
+  \"lens\": \"scout\",
+  \"relevant_files\": [{\"path\": \"...\", \"line_range\": \"...\", \"role\": \"...\"}],
+  \"conventions\": {\"commits\": \"...\", \"testing\": \"...\", \"linting\": \"...\", \"error_handling\": \"...\"},
+  \"patterns\": [\"existing pattern 1\", \"existing pattern 2\"],
+  \"related_issues\": [{\"number\": 0, \"title\": \"...\", \"relevance\": \"...\"}],
+  \"constraints\": [\"architectural constraint 1\"],
+  \"test_coverage\": \"description of existing test coverage for affected areas\",
+  \"library_findings\": [{\"library\": \"...\", \"version\": \"...\", \"relevant_api\": \"...\", \"notes\": \"...\"}],
+  \"approaches\": [
+    {\"name\": \"...\", \"description\": \"...\", \"pros\": [], \"cons\": [], \"complexity\": \"simple|medium|complex\", \"files_touched\": 0}
+  ],
+  \"recommendation\": \"which approach and why\"
+}
+
+## Reminder
+READ-ONLY. No code changes, no commits. Write output JSON to OUTPUT_PATH (compact: | jq -c .).

--- a/experiments/exp9-openrouter-evaluation-r2/score.py
+++ b/experiments/exp9-openrouter-evaluation-r2/score.py
@@ -1,0 +1,300 @@
+"""
+score.py -- Experiment 9: Blind Scorer
+
+Reads sessions/run-NN.json files and applies the exp9 rubric (C1-C8) to
+each run. Outputs results/scores.jsonl (one JSON line per run).
+
+Blind by default: label-map.json is not read during scoring. Use --reveal
+after scoring is complete to append model_key to each line.
+
+## Usage
+
+  uv run python score.py [--reveal] [--label-map PATH]
+"""
+
+import argparse
+import json
+import pathlib
+import sys
+
+EXP9_DIR = pathlib.Path(__file__).parent.resolve()
+RESULTS_DIR = EXP9_DIR / "results"
+SESSIONS_DIR = EXP9_DIR / "sessions"
+RUBRIC_PATH = EXP9_DIR / "rubric.md"
+LABEL_MAP_PATH = EXP9_DIR / "label-map.json"
+
+
+def read_rubric() -> str:
+    """Read the exp9 rubric."""
+    if not RUBRIC_PATH.exists():
+        raise FileNotFoundError(f"Rubric not found: {RUBRIC_PATH.resolve()}")
+    return RUBRIC_PATH.read_text(encoding="utf-8")
+
+
+def read_session_files(sessions_dir: pathlib.Path):
+    """Yield (run_id, data) tuples for each run-NN.json file sorted by run_id."""
+    session_files = sorted(sessions_dir.glob("run-*.json"))
+    for sf in session_files:
+        run_id = sf.stem  # e.g. "run-86"
+        try:
+            data = json.loads(sf.read_text(encoding="utf-8"))
+            yield run_id, data
+        except (json.JSONDecodeError, OSError) as e:
+            print(f"  SKIP {run_id}: {e}", file=sys.stderr)
+            yield run_id, None
+
+
+def score_run(run_id: str, data: dict, rubric_text: str) -> dict:
+    """Score a single run against the C1-C8 rubric using heuristic analysis.
+
+    This is a heuristic scorer that checks for keyword presence in the
+    JSON output text. A human or LLM scorer would re-score in production.
+
+    C1: Identifies and verifies a specific forge module file path
+    C2: References a specific provider trait/struct pattern within the codebase
+    C3: Identifies at least one relevant test file for forge providers
+    C4: References issue #1205 or multi-forge architecture with structural code terms
+    C5: Identifies provider-specific differences (at least 2)
+    C6: Makes an explicit statement about auth flow differences across providers
+    C7: Identifies a non-obvious architectural implication requiring code synthesis
+    C8: Produces valid JSON output with all 11 required handoff schema fields
+    """
+    if data is None:
+        return {
+            "run_id": run_id,
+            "C1": 0,
+            "C2": 0,
+            "C3": 0,
+            "C4": 0,
+            "C5": 0,
+            "C6": 0,
+            "C7": 0,
+            "C8": 0,
+            "total": 0,
+            "latency_ms": None,
+            "cost_usd": None,
+            "timestamp_utc": None,
+        }
+
+    output = data.get("response_text", data.get("output", ""))
+    output_lower = output.lower()
+
+    score = {}
+
+    # C1: Check for forge module file path references
+    has_file_ref = any(
+        keyword in output_lower
+        for keyword in ["forge", "crates/", "src/", ".rs", ".toml", "path:"]
+    )
+    score["C1"] = 1 if has_file_ref else 0
+
+    # C2: Check for provider trait/struct pattern references
+    has_pattern_ref = any(
+        keyword in output_lower
+        for keyword in [
+            "struct",
+            "enum ",
+            "pattern",
+            "trait",
+            "impl ",
+            "provider",
+        ]
+    )
+    score["C2"] = 1 if has_pattern_ref else 0
+
+    # C3: Check for test file or test function references
+    has_test_ref = any(
+        keyword in output_lower for keyword in ["test", "tests/", "_test"]
+    )
+    score["C3"] = 1 if has_test_ref else 0
+
+    # C4: Check for issue #1205 or multi-forge domain + structural keywords
+    has_issue_ref = "#1205" in output_lower
+    has_forge_domain = any(
+        kw in output_lower
+        for kw in [
+            "forge",
+            "gitlab",
+            "gitea",
+            "forgejo",
+            "azure devops",
+            "azure-devops",
+            "multi-forge",
+            "codeberg",
+        ]
+    )
+    has_structural = any(
+        kw in output_lower
+        for kw in ["trait", "aptu-core", "impl ", "backend", "provider"]
+    )
+    score["C4"] = 1 if (has_issue_ref or (has_forge_domain and has_structural)) else 0
+
+    # C5: Check for provider-specific difference patterns (at least 2)
+    provider_keywords = [
+        "gitlab",
+        "gitea",
+        "forgejo",
+        "azure devops",
+        "azure-devops",
+        "github",
+        "auth",
+        "api",
+        "endpoint",
+        "token",
+    ]
+    has_provider_refs = sum(1 for kw in provider_keywords if kw in output_lower)
+    score["C5"] = 1 if has_provider_refs >= 2 else 0
+
+    # C6: Check for auth flow difference references
+    has_auth_ref = any(
+        keyword in output_lower
+        for keyword in [
+            "auth",
+            "token",
+            "oauth",
+            "pat",
+            "authentication",
+            "credential",
+            "login",
+            "access token",
+        ]
+    )
+    score["C6"] = 1 if has_auth_ref else 0
+
+    # C7: Check for non-obvious architectural implications
+    has_arch_ref = any(
+        keyword in output_lower
+        for keyword in [
+            "abstraction",
+            "trait",
+            "dispatch",
+            "routing",
+            "plugin",
+            "rate limit",
+            "versioning",
+            "compat",
+            "migration",
+            "webhook",
+            "parsing",
+            "ssh",
+            "https",
+        ]
+    )
+    score["C7"] = 1 if has_arch_ref else 0
+
+    # C8: Valid JSON per handoff schema (11 required fields)
+    required_fields = {
+        "session_id",
+        "lens",
+        "relevant_files",
+        "conventions",
+        "patterns",
+        "related_issues",
+        "constraints",
+        "test_coverage",
+        "library_findings",
+        "approaches",
+        "recommendation",
+    }
+    try:
+        response_json = json.loads(output)
+        score["C8"] = 1 if required_fields.issubset(set(response_json.keys())) else 0
+    except (json.JSONDecodeError, TypeError, AttributeError):
+        score["C8"] = 0
+
+    total = sum(score.values())
+
+    result = {
+        "run_id": run_id,
+        "C1": score["C1"],
+        "C2": score["C2"],
+        "C3": score["C3"],
+        "C4": score["C4"],
+        "C5": score["C5"],
+        "C6": score["C6"],
+        "C7": score["C7"],
+        "C8": score["C8"],
+        "total": total,
+        "latency_ms": data.get("latency_ms"),
+        "cost_usd": data.get("cost_usd"),
+        "timestamp_utc": data.get("timestamp_utc"),
+    }
+
+    return result
+
+
+def write_scores_jsonl(scores: list, results_dir: pathlib.Path):
+    """Write scores to results/scores.jsonl."""
+    output_path = results_dir / "scores.jsonl"
+    with open(output_path, "w", encoding="utf-8") as f:
+        for s in scores:
+            f.write(json.dumps(s, separators=(",", ":")) + "\n")
+    print(f"Wrote {len(scores)} scores to {output_path}")
+
+
+def load_label_map(label_map_path: pathlib.Path) -> dict:
+    """Load label-map.json mapping run_id -> model_key."""
+    if not label_map_path.exists():
+        print(f"Label map not found: {label_map_path}", file=sys.stderr)
+        return {}
+    return json.loads(label_map_path.read_text(encoding="utf-8"))
+
+
+def reveal_labels(scores: list, label_map: dict) -> list:
+    """Append model_key to each score line based on run_id."""
+    revealed = []
+    for s in scores:
+        run_id = s.get("run_id", "")
+        entry = dict(s)
+        entry["model_key"] = label_map.get(run_id)
+        revealed.append(entry)
+    return revealed
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Blind scorer for Experiment 9")
+    parser.add_argument(
+        "--reveal",
+        action="store_true",
+        help="Reveal model labels after scoring (reads label-map.json)",
+    )
+    parser.add_argument(
+        "--label-map",
+        type=str,
+        default=str(LABEL_MAP_PATH),
+        help=f"Path to label-map.json (default: {LABEL_MAP_PATH})",
+    )
+    args = parser.parse_args()
+
+    rubric_text = read_rubric()
+    print(f"Read rubric ({len(rubric_text)} chars)")
+
+    scores = []
+    for run_id, data in read_session_files(SESSIONS_DIR):
+        result = score_run(run_id, data, rubric_text)
+        scores.append(result)
+        total = result["total"]
+        latency = result.get("latency_ms", "N/A")
+        print(f"  {run_id}: total={total}/8, latency={latency}ms")
+
+    if args.reveal:
+        label_map_path = pathlib.Path(args.label_map)
+        label_map = load_label_map(label_map_path)
+        if label_map:
+            scores = reveal_labels(scores, label_map)
+            print(f"Revealed labels from {label_map_path}")
+
+    write_scores_jsonl(scores, RESULTS_DIR)
+
+    summary = {
+        "n_scores": len(scores),
+        "mean": round(sum(s["total"] for s in scores) / len(scores), 2)
+        if scores
+        else 0,
+        "labels_revealed": args.reveal,
+    }
+    print(f"\nSummary: {json.dumps(summary)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/exp9-openrouter-evaluation-r2/scorer-prompt.md
+++ b/experiments/exp9-openrouter-evaluation-r2/scorer-prompt.md
@@ -1,0 +1,95 @@
+# Experiment 9 Scorer Prompt
+
+Paste this into a new Goose session (no recipe) from the `~/git/dotfiles` directory.
+Run this AFTER all 30 runs are complete. Do NOT run this in the same session as the runner.
+
+---
+
+## Prompt
+
+You are the blind scorer for Experiment 9 (model comparison for SCOUT delegates, round 2). You must score 30 SCOUT delegate outputs against a rubric without knowing which model produced which output.
+
+### Rules
+
+1. You are BLIND. Do not read `experiments/exp9-openrouter-evaluation-r2/label-map.json`. Do not attempt to identify which model produced which run.
+2. Score each run independently. Do not compare runs to each other during scoring.
+3. Each criterion is binary: 1 (met) or 0 (not met). No partial credit.
+4. You must verify claims against the actual aptu codebase before scoring. Clone clouatre-labs/aptu to a temp directory for verification.
+5. No emojis in output.
+
+### Setup
+
+```bash
+cd ~/git/dotfiles
+EXP_DIR=experiments/exp9-openrouter-evaluation-r2
+
+# Verify all 30 run files exist
+ls $EXP_DIR/sessions/run-*.json | wc -l
+# Should be 30 (run-86 to run-115). If not, STOP and report which runs are missing.
+
+# Clone aptu for verification
+APTU_DIR=$(mktemp -d)
+gh repo clone clouatre-labs/aptu $APTU_DIR -- --quiet
+echo "aptu cloned to $APTU_DIR"
+```
+
+### Read the Rubric
+
+```bash
+cat $EXP_DIR/rubric.md
+```
+
+Understand all 8 criteria (C1-C8) before scoring any run.
+
+### Scoring Loop
+
+For each run NN in {86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115}:
+
+1. Read the run output:
+   ```bash
+   cat $EXP_DIR/sessions/run-NN.json | jq .
+   ```
+
+2. For each criterion C1-C8, verify the claim against the aptu codebase:
+   - C1: Does the run identify the correct forge module file path? Verify with `rg` in $APTU_DIR.
+   - C2: Does the run reference provider trait/struct patterns with codebase evidence? Verify the cited code exists.
+   - C3: Does the run identify test files for forge providers? Verify the test files exist.
+   - C4: Does the run reference issue #1205 or multi-forge architecture with structural code terms? Verify the claim.
+   - C5: Does the run identify provider-specific differences? Verify the patterns exist in the codebase.
+   - C6: Does the run note auth flow differences across providers? Verify the claim is technically accurate.
+   - C7: Does the run identify a non-obvious architectural implication with specific evidence? Verify the evidence.
+   - C8: Is the output valid JSON with all 11 required schema fields? Validate with `jq`.
+
+3. Record the score for this run before moving to the next.
+
+### Output
+
+After scoring all 30 runs, write `scores.json`:
+
+```bash
+cat > $EXP_DIR/scores.json << 'SCORES_EOF'
+{
+  "scorer": "claude-haiku-4-5-blind",
+  "rubric_version": "exp9-v1.0",
+  "timestamp": "<ISO8601>",
+  "runs": {
+    "run-86": {
+      "C1": 0, "C2": 0, "C3": 0, "C4": 0, "C5": 0, "C6": 0, "C7": 0, "C8": 0,
+      "total": 0,
+      "notes": "Brief justification for each 0 score"
+    },
+    "run-87": { "..." : "..." }
+  }
+}
+SCORES_EOF
+```
+
+Replace placeholder values with actual scores. Every 0 score MUST have a note explaining why.
+
+### After Scoring
+
+1. Verify scores.json is valid JSON: `jq . $EXP_DIR/scores.json > /dev/null && echo "VALID"`
+2. Report summary: score distribution (min, max, median, mean) across all 30 runs
+3. **STOP.** Do not read label-map.json. Do not compute group statistics. The orchestrator does that in a separate step.
+
+Say: "Scoring complete. 30 runs scored. Ready for analysis phase."

--- a/experiments/exp9-openrouter-evaluation-r2/uv.lock
+++ b/experiments/exp9-openrouter-evaluation-r2/uv.lock
@@ -1,0 +1,319 @@
+version = 1
+revision = 3
+requires-python = ">=3.13"
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/72/5562aabb8dd7181e8e860622a38bea08d17842b99ecd4c91f84ac95251b0/anyio-4.14.1.tar.gz", hash = "sha256:8d648a3544c1a700e3ff78615cd679e4c5c3f149904287e73687b2596963629e", size = 254831, upload-time = "2026-06-24T20:56:06.017Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/7b/90df4a0a816d98d6ea26f559d87836d494a2cf1fcf063be67df50a7bcc30/anyio-4.14.1-py3-none-any.whl", hash = "sha256:4e5533c5b8ff0a24f5d7a176cbe6877129cd183893f66b537f8f227d10527d72", size = 124875, upload-time = "2026-06-24T20:56:04.413Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.6.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "exp9-openrouter-evaluation-r2"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "openai" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "openai", specifier = ">=1.0.0" },
+    { name = "ruff", specifier = ">=0.9.0" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "jiter"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/1f/10936e16d8860c70698a1aa939a46aa0224813b782bce4e000e637da0b2d/jiter-0.16.0.tar.gz", hash = "sha256:7b24c3492c5f4f84a37946ad9cf504910cf6a782d6a4e0689b6673c5894b4a1c", size = 176431, upload-time = "2026-06-29T13:05:13.657Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/c0/555fc60473d30d66894ba825e63615e3be7524fac23858356afa7a38906c/jiter-0.16.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:41977aa5654023948c2dae2a81cbf9c43343954bef1cd59a154dd15a4d84c195", size = 306203, upload-time = "2026-06-29T13:03:36.243Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/2b/c3eaf16f5d7c9bad66ea32f40a95bd169b29a91217fcc7f081375157e99c/jiter-0.16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d28bb3c26762358dadf3e5bf0bccd29ae987d65e6988d2e6f49829c76b003c09", size = 306489, upload-time = "2026-06-29T13:03:37.846Z" },
+    { url = "https://files.pythonhosted.org/packages/96/3f/02fdfc6705cad96127d883af5c34e4867f554f29ec7705ec1a46156400a9/jiter-0.16.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0542a7189c26920778658fc8fcf2af8bae05bae9924577f71804acef37996536", size = 335453, upload-time = "2026-06-29T13:03:39.221Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a6/e4bda5920d4b0d7c5dfb7174ce4a6b2e4d3e11c9162c452ef0eab4cdbdbd/jiter-0.16.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8fb8de1e23a0cb2a7f53c335049c7b72b6db41aa6227cdcc0972a1de5cb39450", size = 361625, upload-time = "2026-06-29T13:03:40.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/97/4e6b59b2c6e55cbb3e183595f81ad65dcfb21c915fee5e19e335df21bc55/jiter-0.16.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b72d0b2990ca754a9102779ac98d8597b7cb31678958562214a007f909eab78e", size = 456958, upload-time = "2026-06-29T13:03:42.074Z" },
+    { url = "https://files.pythonhosted.org/packages/15/e0/97e9557686d2f94f4b93786eccb7eed28e9228ad132ea8237f44727314a7/jiter-0.16.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d5f91b1c27fc22a57993d5a5cb8a627cb8ed4b10502716fac1ffbfe1d19d84e8", size = 372017, upload-time = "2026-06-29T13:03:43.658Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/94/db768b6938e0df35c86beeba3dfbbb025c9ee5c19e1aa271f2396e50864d/jiter-0.16.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c682bea068a90b764577bdb78a60a4c1d1606daf9cd4c893832a37c7cc9d9026", size = 343320, upload-time = "2026-06-29T13:03:45.226Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/d6/5a59d938244a30735fe62d9433fd325f9021ea29d89780ea4596ea93bc89/jiter-0.16.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:8d031aabecc4f1b6276adfb42e3aabb77c89d468bf616600e8d3a11328929053", size = 350520, upload-time = "2026-06-29T13:03:46.671Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f8/c4a857f49c9af125f6bbcac7e3eee7f7978ed89682833062e2dbf62576b1/jiter-0.16.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:eab2cd170150e70153de16896a1774e3a1dca80154c56b54d7a812c479a7165e", size = 387550, upload-time = "2026-06-29T13:03:48.361Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/d6/5fbc2f7d6b67b754caa61a993a2e626e815dec47ffc2f9e35f01adfebec7/jiter-0.16.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:6edb63a46e65a82c26800a868e49b2cac30dd5a4218b88d74bc2c848c8ad60bb", size = 515424, upload-time = "2026-06-29T13:03:49.881Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/54/284f0164b64a5fed915fea6ba7e9ba9b3d8d37c67d59cf2e3bb99d45cdfe/jiter-0.16.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:659039cc50b5addcc35fcc87ae2c1833b7c0a8e5326ef631a75e4478447bcf84", size = 546981, upload-time = "2026-06-29T13:03:51.363Z" },
+    { url = "https://files.pythonhosted.org/packages/13/c5/2a467585a576594384e1d2c43e1224deaafc085f24e243529cf98beef8e1/jiter-0.16.0-cp313-cp313-win32.whl", hash = "sha256:c9c53be232c2e206ef9cdbad81a48bfa74c3d3f08bcf8124630a8a748aad993e", size = 202853, upload-time = "2026-06-29T13:03:53.015Z" },
+    { url = "https://files.pythonhosted.org/packages/88/6a/de61d04b9eec69c71719968d2f716532a3bc121170c44a39e14979c6be81/jiter-0.16.0-cp313-cp313-win_amd64.whl", hash = "sha256:baad945ed47f163ad833314f8e3288c396118934f94e7bbb9e243ce4b341a4fd", size = 196160, upload-time = "2026-06-29T13:03:54.447Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4b/b390ed59bafb3f31d008d1218578f10327714484b334439947f7e5b11e7f/jiter-0.16.0-cp313-cp313-win_arm64.whl", hash = "sha256:3c1fd2dbe1b0af19e987f03fe66c5f5bd105a2229c1aff4ab14890b24f41d21a", size = 189862, upload-time = "2026-06-29T13:03:55.754Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/89/bc4f1b57d5da938fd344a466396541e586d161320d70bffd929aaafcd8f4/jiter-0.16.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:b2c61484666ad42726029af0c00ef4541f0f3b5cdc550221f56c2343208018ee", size = 308239, upload-time = "2026-06-29T13:03:57.205Z" },
+    { url = "https://files.pythonhosted.org/packages/65/7a/c415453e5213001bf3b411ff65dec3d303b0e76a4a2cfea9768cd4960994/jiter-0.16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:63efadc657488f45db1c676d81e704cac2abf3fdb892def1faea61db053127e2", size = 308928, upload-time = "2026-06-29T13:03:58.643Z" },
+    { url = "https://files.pythonhosted.org/packages/11/fc/1f4fb7ebf9a724c7741994f4aae18fba1e2f3133df14521a79194952c34a/jiter-0.16.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cf0d73f50e7b6935677854f6e8e31d499ca7064dd24734f703e060f5b237d883", size = 336998, upload-time = "2026-06-29T13:04:00.071Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/8d/72cadaac05ccfa7cc3a0a2232862e6c72443ca40cf300ba8b57f9f18b69b/jiter-0.16.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bf3ea07d9bc8e7d03a9fbc051295462e6dbc295b894fd72457c3136e3e43d898", size = 362112, upload-time = "2026-06-29T13:04:01.52Z" },
+    { url = "https://files.pythonhosted.org/packages/58/4a/c4b0d5f651fda90a24ffce9f8d56cde462a2e09d31ae3de3c68cef34c04e/jiter-0.16.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:26798522707abb47d767db536e4148ceac1b14446bf028ee85e579a2e043cfe5", size = 459807, upload-time = "2026-06-29T13:04:03.214Z" },
+    { url = "https://files.pythonhosted.org/packages/80/58/ef77879ea9aa56b50824edc5a445e226422c7a8d211f3fd2a56bcb9493cf/jiter-0.16.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bc837c1b9631be10abfe0191537fe8009838204cec7e44827401ace390ddb567", size = 373181, upload-time = "2026-06-29T13:04:04.629Z" },
+    { url = "https://files.pythonhosted.org/packages/49/2e/ffbc3f254e4d8a66da3062c624a7df4b7c2b2cf9e1fe43cf394b3e104041/jiter-0.16.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49060fd70737fad59d33ba9dcc0d83247dc9e77187de26053a19c16c9f32bd69", size = 344927, upload-time = "2026-06-29T13:04:06.067Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/f6/0be5dc6d64a89f80aa8fec984f94dedb2973e251edcae55841d60786d578/jiter-0.16.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:adbb8edeadd431bc4477879d5d371ece7cb1334486584e0f252656dd7ffada29", size = 352754, upload-time = "2026-06-29T13:04:07.477Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6e/7d31243b3b91cd261dd19e9d3557fc3251a80883d3d8049c86174e7ab7af/jiter-0.16.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:31aaee5b80f672c1dc21272bcfb9cbdcfc1ea04ff50f00ed5af500b80c44fa93", size = 390553, upload-time = "2026-06-29T13:04:08.92Z" },
+    { url = "https://files.pythonhosted.org/packages/25/33/51ae371fde3c88897520f62b4d5f8b27ad7103e2bb10812ff52195609853/jiter-0.16.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:6722bcef4ffc86c835574b1b2fac6b33b9fb4a889c781e67950e891591f3c55a", size = 516900, upload-time = "2026-06-29T13:04:10.407Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/45/6449b3d123ea439ba79507c657288f461d55049e7bcbdc2cf8eb8210f491/jiter-0.16.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:5ab4f50ff971b611d656554ea10b75f80097392c827bc32923c6eeb6386c8b00", size = 548754, upload-time = "2026-06-29T13:04:12.046Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/e7/fd2fb11ae3e2649333da3aa170d04d7b3000bbdc3b270f6513382fdf4e04/jiter-0.16.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:710cc51d4ebdcd3c1f70b232c1db1ea1344a075770422bbd4bede5708335acbe", size = 122381, upload-time = "2026-06-29T13:04:13.413Z" },
+    { url = "https://files.pythonhosted.org/packages/26/80/f0b147a62c315a164ed2168908286ca302310824c218d3aae52b06c0c9a9/jiter-0.16.0-cp314-cp314-win32.whl", hash = "sha256:57b37fc887a32d44798e4d8ebfa7c9683ff3da1d5bf38f08d1bb3573ccb39106", size = 204578, upload-time = "2026-06-29T13:04:14.813Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e6/4758a14304b4523a6f5adb2419340086aa3593bd4327c2b25b5948a90548/jiter-0.16.0-cp314-cp314-win_amd64.whl", hash = "sha256:cbd18dd5e2df96b580487b5745adf57ef64ad89ba2d9662fc3c19386acce7db8", size = 198154, upload-time = "2026-06-29T13:04:16.272Z" },
+    { url = "https://files.pythonhosted.org/packages/26/be/41fa54a2e7ea41d6c99f1dc5b1f0fd4cb474680304b5d268dd518e81da3a/jiter-0.16.0-cp314-cp314-win_arm64.whl", hash = "sha256:a32d2027a9fa67f109ff245a3252ece3ccc32cc56703e1deab6cc846a59e0585", size = 191458, upload-time = "2026-06-29T13:04:17.707Z" },
+    { url = "https://files.pythonhosted.org/packages/81/6b/59127338b86d9fe4d99418f5a15118bea778103ee0fe9d9dd7e0af174e95/jiter-0.16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2577196f4474ef3fc4779a088a23b0897bbf86f9ea3679c372d45b8383b43207", size = 316739, upload-time = "2026-06-29T13:04:19.663Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/95/49461034d5388196d3dabf98748935f017b7785d8f3f5349f834bcc4ed0d/jiter-0.16.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:616e89e008a93c01104161c75b4988e58716b01d62307ebfe161e52a56d2a818", size = 340911, upload-time = "2026-06-29T13:04:21.257Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/97/a4369f2fb82cb3dda13b98622f31249b2e014b223fe64ee534413ad72294/jiter-0.16.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e2e9efbe042210df657bade597f66d6d75723e3d8f45a12ea6d8167ff8bbce3", size = 361747, upload-time = "2026-06-29T13:04:22.677Z" },
+    { url = "https://files.pythonhosted.org/packages/28/51/49b6ed456261646e1906016a6760367a28aacd3c24805e4e5fe64116c1db/jiter-0.16.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3f4d9e473a5ce7d27fef8b848df4dc16e283893d3f53b4a585e72c9595f3c284", size = 460225, upload-time = "2026-06-29T13:04:24.441Z" },
+    { url = "https://files.pythonhosted.org/packages/33/b5/5689aff4f66c5b60be63106e591dbfcba2190df97d2c9c7cf052361ddb98/jiter-0.16.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8d30a4a1c87713060c8d1cc59a7b6c8fb6b8ef0a6900368014c76c87922a2929", size = 373169, upload-time = "2026-06-29T13:04:25.884Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/96/3ae1b85ee0d6d6cab254fb7f8da018272b932bbf2d69b07e98aa2a96c746/jiter-0.16.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bae96332410f866e5900d809298b1ed82735932986c672495f9701daacd80620", size = 350332, upload-time = "2026-06-29T13:04:27.302Z" },
+    { url = "https://files.pythonhosted.org/packages/15/32/c99d7bafd78986556c95bf60ce84c6cc98786eac56066c12d7f828bb6747/jiter-0.16.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:da3d7ec75dc83bb18bca888b5edfae0656a26849056c59e05a7728badd17e7af", size = 353377, upload-time = "2026-06-29T13:04:28.731Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/f99a8e571287c3dec766bcc18528bbe8e8fb5365522ab5e6d64c93e87066/jiter-0.16.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ee6162b77d49a9939229df666dfa8af3e656b6701b54c4c84966d740e189264e", size = 387746, upload-time = "2026-06-29T13:04:30.319Z" },
+    { url = "https://files.pythonhosted.org/packages/75/69/c78a5b3f71040e34eb5917df26fb7ae9a2174cad1ccbf277512507c53a6e/jiter-0.16.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:63ffdbdae7d4499f4cda14eadc12ddcabef0fc0c081191bdc2247489cb698077", size = 517292, upload-time = "2026-06-29T13:04:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/f7/095b38eda4c70d03651c403f29a5590f16d12ddc5d544aac9f9cddf72277/jiter-0.16.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a111256a7193bea0759267b10385e5870949c239ed7b6ddbaaf57573edb38734", size = 549259, upload-time = "2026-06-29T13:04:33.721Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/c5/6a0207d90e5f656d95af98ebd0934f382d37674416f215aeda2ff8063e51/jiter-0.16.0-cp314-cp314t-win32.whl", hash = "sha256:de5ba8763e56b793561f43bed197c9ea55776daa5e9a6b91eed68a909bc9cdbf", size = 206523, upload-time = "2026-06-29T13:04:35.068Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/31/c757d5f30a8980fd945ce7b98be10be9e4ff59c7c42f5fd86804c2e87db8/jiter-0.16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b8a3f9a6008048fe9def7bf465180564a6e458047d2ce499149cfbe73c3ae9db", size = 200366, upload-time = "2026-06-29T13:04:36.61Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/a2/d88de6d313d734a544a7901353ad5db67cb38dcfcd91713b7979dafc345d/jiter-0.16.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0fa25b09b13075c46f5bc174f2690525a925a4fc2f7c82969a2bbabff22386ce", size = 190516, upload-time = "2026-06-29T13:04:38.004Z" },
+]
+
+[[package]]
+name = "openai"
+version = "2.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/f5/7c7cb955305cb41f7f3c5fd7e0e38bf6bbf2658468863d4b7b868a5cb8df/openai-2.44.0.tar.gz", hash = "sha256:68a5a5ffad82b8ff7d451c437529fb64f7c3b8123aaf0c021966a882d9e3947d", size = 988753, upload-time = "2026-06-24T20:56:02.293Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/f4/561ed79fd94876160018a5e75254cfcb9b0e62d4dded9dcb20072e86d623/openai-2.44.0-py3-none-any.whl", hash = "sha256:0a2a3ab2e29aeda368700f662ff9ba0f9df17ba4c54577a64e08b8115a3cc0ad", size = 1366216, upload-time = "2026-06-24T20:55:58.882Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/dc/35b341fc554ba02f217fc10da57d1a75168cfbcf75b0ef2202176d4c4f2d/ruff-0.15.20.tar.gz", hash = "sha256:1416eb04349192646b54de98f146c4f59afe37d0decfc02c3cbbf396f3a28566", size = 4755489, upload-time = "2026-06-25T17:20:37.578Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/d9/2d5014f0253ba541d2061d9fa7193f48e941c8b21bb88a7ff9bbe0bd0596/ruff-0.15.20-py3-none-linux_armv6l.whl", hash = "sha256:00e188c53e499c3c1637f73c91dcf2fb56d576cab76ce1be50a27c4e80e37078", size = 10839665, upload-time = "2026-06-25T17:19:44.702Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/d3/ac1798ba64f670698867fcfc591d50e7e421bef137db564858f619a30fcf/ruff-0.15.20-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9ebd1fd9b9c95fc0bd7b2761aebec1f030013d2e193a2901b224af68fe47251b", size = 11208649, upload-time = "2026-06-25T17:19:48.787Z" },
+    { url = "https://files.pythonhosted.org/packages/47/47/d3ac899991202095dfcf3d5176be4272642be3cf981a2f1a30f72a2afb95/ruff-0.15.20-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c5b16cdd67ca108185cd36dce98c576350c03b1660a751de725fb049193a0632", size = 10622638, upload-time = "2026-06-25T17:19:51.354Z" },
+    { url = "https://files.pythonhosted.org/packages/33/13/4e043fe30aa94d4ff5213a9881fc296d12960f5971b234a5263fdc225312/ruff-0.15.20-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3413bb3c3d2ca6a8208f1f4809cd2dca3c6de6d0b491c0e70847672bde6e6efd", size = 10984227, upload-time = "2026-06-25T17:19:54.044Z" },
+    { url = "https://files.pythonhosted.org/packages/76/e6/92e7bf40388bc5800073b96564f56264f7e48bfd1a498f5ced6ae6d5a769/ruff-0.15.20-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bd7ec42b3bb3da066488db093308a69c4ac5ee6d2af333a86ba6e2eb2e7dd44b", size = 10622882, upload-time = "2026-06-25T17:19:57.037Z" },
+    { url = "https://files.pythonhosted.org/packages/13/7a/43460be3f24495a3aa46d4b16873e2c4941b3b5f0b00cf88c03b7b94b339/ruff-0.15.20-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e1a36ad0eb77fba9aabfb69ede54de6f376d04ac18ebea022847046d340a8267", size = 11474808, upload-time = "2026-06-25T17:20:00.357Z" },
+    { url = "https://files.pythonhosted.org/packages/27/a0/f37077884873221c6b33b4ab49eb18f9f88e54a16a25a5bca59bef46dd66/ruff-0.15.20-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b6df3b1e4610432f0386dba04d853b5f08cbbc903410c6fcc02f620f05aff53c", size = 12293094, upload-time = "2026-06-25T17:20:03.446Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/74/165545b60256a9704c21ac0ec4a0d07933b320812f9584836c9f4aca4292/ruff-0.15.20-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e89f198a1ea6ef0d727c1cf16088bc91a6cb0ab947dedc966715691647186eae", size = 11526176, upload-time = "2026-06-25T17:20:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/86/b1/a976a136d40ade83ce743578399865f57001003a409acadc0ecbb3051082/ruff-0.15.20-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:309809086c2acb67624950a3c8133e80f32d0d3e27106c0cd60ff26657c9f24b", size = 11520767, upload-time = "2026-06-25T17:20:09.191Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0f/f032696cb01c9b54c0263fa393474d7758f1cdc021a01b04e3cbc2500999/ruff-0.15.20-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:2d2374caa2f2c2f9e2b7da0a50802cfb8b79f55a9b5e49379f564544fbf56487", size = 11500132, upload-time = "2026-06-25T17:20:13.602Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f4/51b1a14bc69e8c224b15dab9cce8e99b425e0455d462caa2b3c9be2b6a8e/ruff-0.15.20-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a1ed17b65293e0c2f22fc387bc13198a5de94bf4429589b0ff6946b0feaf21a3", size = 10943828, upload-time = "2026-06-25T17:20:16.635Z" },
+    { url = "https://files.pythonhosted.org/packages/71/4b/fe267640783cd02bf6c5cc290b1df1051be2ec294c678b5c15fe19e52343/ruff-0.15.20-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:f701305e66b38ea6c91882490eb73459796808e4c6362a1b765255e0cdcd4053", size = 10645418, upload-time = "2026-06-25T17:20:19.4Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/c0/a65aa4ec2f5e87a1df32dc3ec1fede434fe3dfd5cbcf3b503cafc676ab54/ruff-0.15.20-py3-none-musllinux_1_2_i686.whl", hash = "sha256:5b9c0c367ad8e5d0d5b5b8537864c469a0a0e55417aadfbeca41fa61333be9f4", size = 11211770, upload-time = "2026-06-25T17:20:22.033Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/a4/0caa331d954ae2723d729d351c989cb4ca8b6077d5c6c2cb6de75e98c041/ruff-0.15.20-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:01cc00dd58f0df339d0e902219dd53990ea99996a0344e5d9cc8d45d5307e460", size = 11618698, upload-time = "2026-06-25T17:20:25.259Z" },
+    { url = "https://files.pythonhosted.org/packages/10/9b/5f14927848d2fd4aa891fd88d883788c5a7baba561c7874732364045708c/ruff-0.15.20-py3-none-win32.whl", hash = "sha256:ed65ef510e43a137207e0f01cfcf998aeddb1aeeda5c9d35023e910284d7cf21", size = 10857322, upload-time = "2026-06-25T17:20:28.612Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/f0/fe47c501f9dea92a26d788ff98bb5d92ed4cb4c88792c5c88af6b697dc8e/ruff-0.15.20-py3-none-win_amd64.whl", hash = "sha256:a525c81c70fb0380344dd1d8745d8cc1c890b7fc94a58d5a07bd8eb9557b8415", size = 11993274, upload-time = "2026-06-25T17:20:31.871Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/2b/9555445e1201d92b3195f45cdb153a0b68f24e0a4273f6e3d5ab46e212bb/ruff-0.15.20-py3-none-win_arm64.whl", hash = "sha256:2f5b2a6d614e8700388806a14996c40fab2c47b819ef57d790a34878858ed9ca", size = 11343498, upload-time = "2026-06-25T17:20:35.03Z" },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.68.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/5f/57ff8b434839e70dab45601284ea413e947a63799891b7553e5960a793a8/tqdm-4.68.4.tar.gz", hash = "sha256:19829c9673638f2a0b8617da4cdcb927e831cd88bcfcb6e78d42a4d1af131520", size = 792418, upload-time = "2026-07-07T09:58:18.369Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/2a/5e5e750890ada51017d18d0d4c30da696e5b5bd3180947729927628fc3cb/tqdm-4.68.4-py3-none-any.whl", hash = "sha256:5168118b2368f48c561afda8020fd79195b1bdb0bdf8086b88442c267a315dc2", size = 676612, upload-time = "2026-07-07T09:58:16.256Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]


### PR DESCRIPTION
## Experiment 9: OpenRouter Evaluation Round 2

Redesign of exp8, which produced invalid results due to three structural defects. This PR adds the corrected experiment scaffold. No inference results are included -- pilot runs (n=1 per model) gate the full run.

## Why exp8 was invalid

**Defect 1: Wrong prompt.** `run_inference.py` sent the exp3 orchestrator meta-prompt as the user message. Models responded as orchestrators ("ready to start?") rather than performing the SCOUT codebase research task. All 30 sessions are unusable.

**Defect 2: C4 depended on closed issues.** The C4 criterion checked for `#735`, `#736`, `#737` in the response. All three issues in `clouatre-labs/aptu` are closed. Models that hallucinated the reference scored 1 for the wrong reason.

**Defect 3: C8 was trivially true.** `score.py` awarded C8=1 if the session JSON file parsed -- always true. The rubric requires the model's response to be valid JSON matching the 11-field SCOUT handoff schema.

## Fixes in exp9

| Fix | What changed |
|-----|-------------|
| Prompt | `runner-prompt.md` contains the raw SCOUT task (extracted from exp3), retargeted to `clouatre-labs/aptu#1205` (multi-forge support, open) |
| C4 | Criterion now checks for `#1205` or forge-domain keywords (`forge`, `gitlab`, `gitea`, `forgejo`, `azure-devops`) combined with structural keywords (`trait`, `aptu-core`, `impl`, `backend`, `provider`) |
| C8 | `score.py` parses `response_text` as JSON and checks for all 11 required SCOUT schema fields; returns 0 if not valid JSON or any field missing |
| Scorer | `scorer-prompt.md` adapted from exp3 with updated EXP_DIR, run count, and codebase verification steps for #1205 |

## Alignment with paper findings

The rubric-runner alignment principle from the ceiling-effects paper (A = k_r/k, gate = 1.0) was the diagnostic framework used to identify defects 1 and 3. All C1-C8 criteria are now traceable to explicit instructions in `runner-prompt.md`.

## Run configuration

| Field | Value |
|-------|-------|
| Models | gemma4, haiku45, sonnet46 (same as exp8) |
| Endpoint | OpenRouter (same as exp8) |
| Run IDs | run-86 to run-115 (continuing exp8 numbering) |
| Pilot runs | run-86, run-96, run-106 (one per model, `--pilot` flag) |
| Full runs per model | 10 (after pilot validation) |
| Task | SCOUT research on `clouatre-labs/aptu#1205` |

## Files

- `runner-prompt.md` -- SCOUT task prompt sent to models (not the orchestrator wrapper)
- `run_inference.py` -- OpenRouter client with `--pilot` and `--dry-run` flags
- `score.py` -- Fixed C4 and C8, exp9 paths
- `rubric.md` -- C1-C8 with rewritten C4 (anchored to #1205) and C8 (JSON schema validation)
- `scorer-prompt.md` -- LLM judge instructions adapted from exp3
- `pyproject.toml` + `uv.lock` -- Python deps (openai, ruff)
