### PR TITLE
feat(exp9): replace claude-sonnet-4.6 with claude-sonnet-5

### DIFF
--- a/experiments/exp9-openrouter-evaluation-r2/README.md
+++ b/experiments/exp9-openrouter-evaluation-r2/README.md
@@ -4,7 +4,7 @@ Replicates Experiment 8 on a new task (aptu#1205: multi-forge support) with thre
 
 ## Research Question
 
-When routing all three models through a single OpenRouter endpoint, does the ranking (Gemma 4 vs Haiku 4.5 vs Sonnet 4.6) replicate across tasks, or are the exp8 results task-specific?
+When routing all three models through a single OpenRouter endpoint, does the ranking (Gemma 4 vs Haiku 4.5 vs Sonnet 5) replicate across tasks, or are the exp8 results task-specific?
 
 ## Models
 
@@ -12,14 +12,14 @@ When routing all three models through a single OpenRouter endpoint, does the ran
 |-------|-----|---------|---------------|----------------|
 | Google Gemma 4 26B-A4B | OpenRouter | run-86 to run-95 | $0.06 | $0.33 |
 | Claude Haiku 4.5 | OpenRouter | run-96 to run-105 | $1.00 | $5.00 |
-| Claude Sonnet 4.6 | OpenRouter | run-106 to run-115 | $3.00 | $15.00 |
+| Claude Sonnet 5 | OpenRouter | run-106 to run-115 | $2.00 | $10.00 |
 
 ## Run Configuration
 
 | Config | Value |
 |--------|-------|
 | Total runs | 30 (10 per model) |
-| Pilot runs | run-86 (gemma4), run-96 (haiku45), run-106 (sonnet46) |
+| Pilot runs | run-86 (gemma4), run-96 (haiku45), run-106 (sonnet5) |
 | Endpoint | OpenRouter (https://openrouter.ai/api/v1) |
 | Task | SCOUT research on clouatre-labs/aptu#1205 |
 | Max tokens | 4096 |

--- a/experiments/exp9-openrouter-evaluation-r2/run_inference.py
+++ b/experiments/exp9-openrouter-evaluation-r2/run_inference.py
@@ -1,7 +1,7 @@
 """
 run_inference.py -- Experiment 9: OpenRouter Model Evaluation (Round 2)
 
-Runs Gemma 4 26B-A4B, Claude Haiku 4.5, and Claude Sonnet 4.6 through
+Runs Gemma 4 26B-A4B, Claude Haiku 4.5, and Claude Sonnet 5 through
 a single OpenRouter endpoint (base_url=https://openrouter.ai/api/v1) on
 the exp9 runner prompt (adapted from exp3 SCOUT instructions for #1205).
 
@@ -15,7 +15,7 @@ OpenRouter base URL: https://openrouter.ai/api/v1
   uv run python run_inference.py [--dry-run] [--model MODEL_KEY] [--runs N] [--pilot]
 
   --dry-run   Print config and exit; no API calls
-  --model     One of: gemma4, haiku45, sonnet46 (default: all)
+  --model     One of: gemma4, haiku45, sonnet5 (default: all)
   --runs      Number of runs per model (default: 10)
   --pilot     Run only one run per model (run-86, run-96, run-106) and exit
 """
@@ -68,8 +68,8 @@ MODEL_CONFIGS = {
         "input_price_per_mtok": 1.00,
         "output_price_per_mtok": 5.00,
     },
-    "sonnet46": {
-        "model_id": "anthropic/claude-sonnet-4.6",
+    "sonnet5": {
+        "model_id": "anthropic/claude-sonnet-5",
         "run_ids": [
             "run-106",
             "run-107",
@@ -82,8 +82,8 @@ MODEL_CONFIGS = {
             "run-114",
             "run-115",
         ],
-        "input_price_per_mtok": 3.00,
-        "output_price_per_mtok": 15.00,
+        "input_price_per_mtok": 2.00,
+        "output_price_per_mtok": 10.00,
     },
 }
 
@@ -98,7 +98,7 @@ OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 PILOT_RUN_IDS = {
     "gemma4": "run-86",
     "haiku45": "run-96",
-    "sonnet46": "run-106",
+    "sonnet5": "run-106",
 }
 
 


### PR DESCRIPTION
## Summary

Replace Claude Sonnet 4.6 with Claude Sonnet 5 in exp9. Updated model key from sonnet46 to sonnet5, model ID to anthropic/claude-sonnet-5, pricing to $2.00/$10.00 per million tokens (33% cheaper), module docstring, help text, and README documentation.

## Changes

experiments/exp9-openrouter-evaluation-r2/run_inference.py
experiments/exp9-openrouter-evaluation-r2/README.md

## Test plan

- [x] Tests pass (see 03-build.json test_results: 3 passed, 0 failed)
- [x] Linter clean (ruff check passed)
- [x] Security scan clean (no findings)
