### PR TITLE
fix(exp9): fix --pilot break, add json_object response_format, strip fences, add --skip-existing

### DIFF
--- a/experiments/exp9-openrouter-evaluation-r2/run_inference.py
+++ b/experiments/exp9-openrouter-evaluation-r2/run_inference.py
@@ -145,10 +145,12 @@ def run_single(
     config = MODEL_CONFIGS[model_key]
     model_id = config["model_id"]
 
-    # Interpolate placeholders
-    output_path = str(sessions_dir / f"{run_id}.json")
+    # Interpolate placeholders.
+    # OUTPUT_PATH is replaced with a directive telling the model to return JSON
+    # as its response content (the script captures API output directly; no file
+    # write is possible or needed from inside the model).
     interpolated_prompt = prompt.replace("RUN_ID", run_id).replace(
-        "OUTPUT_PATH", output_path
+        "OUTPUT_PATH", "<your response content>"
     )
 
     if dry_run:
@@ -171,9 +173,27 @@ def run_single(
         try:
             response = client.chat.completions.create(
                 model=model_id,
-                messages=[{"role": "user", "content": interpolated_prompt}],
+                messages=[
+                    {
+                        "role": "system",
+                        "content": (
+                            "You are participating in a benchmark that measures parametric knowledge "
+                            "about software architecture and open-source Rust ecosystems. "
+                            "Use your training knowledge to answer -- do not attempt to execute "
+                            "shell commands, clone repositories, or call tools. "
+                            "The steps in the user message describe what to reason about, not "
+                            "literal actions to perform. Synthesize the best answer you can from "
+                            "what you already know about the codebase and ecosystem. "
+                            "Your response MUST be a single raw JSON object. "
+                            "Start your response with '{' and end with '}'. "
+                            "No markdown fences, no prose before or after the JSON."
+                        ),
+                    },
+                    {"role": "user", "content": interpolated_prompt},
+                ],
                 max_tokens=4096,
                 temperature=0.5,
+                response_format={"type": "json_object"},
             )
             break
         except openai.RateLimitError as e:
@@ -189,7 +209,17 @@ def run_single(
                 raise e
 
     latency_ms = int((time.monotonic() - start) * 1000)
-    output_text = response.choices[0].message.content or ""
+    raw_text = response.choices[0].message.content or ""
+    # Strip markdown fences that some models emit despite response_format=json_object.
+    # Handles ```json\n...\n``` and ``` ... ``` variants.
+    output_text = raw_text.strip()
+    if output_text.startswith("```"):
+        # Drop the opening fence line and closing fence
+        lines = output_text.splitlines()
+        # Find first line that is pure fence (```...) and skip it
+        output_text = "\n".join(lines[1:])
+        if output_text.rstrip().endswith("```"):
+            output_text = output_text.rstrip()[:-3].rstrip()
     input_tokens = response.usage.prompt_tokens if response.usage else 0
     output_tokens = response.usage.completion_tokens if response.usage else 0
     cost_usd = compute_cost_usd(input_tokens, output_tokens, config)
@@ -331,6 +361,11 @@ def main():
         action="store_true",
         help="Run only one run per model (run-86, run-96, run-106) and exit",
     )
+    parser.add_argument(
+        "--skip-existing",
+        action="store_true",
+        help="Skip run IDs that already have a session file in sessions/",
+    )
     args = parser.parse_args()
 
     if args.dry_run:
@@ -367,6 +402,9 @@ def main():
             run_ids = config["run_ids"][: args.runs]
 
         for run_id in run_ids:
+            if args.skip_existing and (SESSIONS_DIR / f"{run_id}.json").exists():
+                print(f"  Skipping {run_id} (already exists)")
+                continue
             print(f"  Starting {run_id}...")
             try:
                 result = run_single(
@@ -399,9 +437,6 @@ def main():
                 write_session(error_result)
                 all_results.append(error_result)
                 print(f"  ERROR: {run_id} -- {e}")
-
-        if args.pilot:
-            break
 
     # Write cost summary after all runs
     write_cost_summary(all_results)

--- a/experiments/exp9-openrouter-evaluation-r2/run_inference.py
+++ b/experiments/exp9-openrouter-evaluation-r2/run_inference.py
@@ -210,16 +210,14 @@ def run_single(
 
     latency_ms = int((time.monotonic() - start) * 1000)
     raw_text = response.choices[0].message.content or ""
-    # Strip markdown fences that some models emit despite response_format=json_object.
-    # Handles ```json\n...\n``` and ``` ... ``` variants.
-    output_text = raw_text.strip()
-    if output_text.startswith("```"):
-        # Drop the opening fence line and closing fence
-        lines = output_text.splitlines()
-        # Find first line that is pure fence (```...) and skip it
-        output_text = "\n".join(lines[1:])
-        if output_text.rstrip().endswith("```"):
-            output_text = output_text.rstrip()[:-3].rstrip()
+    # Extract JSON by finding the first '{' and last '}', discarding any
+    # markdown fences or prose that some models emit around the object.
+    start_idx = raw_text.find("{")
+    end_idx = raw_text.rfind("}")
+    if start_idx != -1 and end_idx != -1 and end_idx >= start_idx:
+        output_text = raw_text[start_idx : end_idx + 1]
+    else:
+        output_text = raw_text
     input_tokens = response.usage.prompt_tokens if response.usage else 0
     output_tokens = response.usage.completion_tokens if response.usage else 0
     cost_usd = compute_cost_usd(input_tokens, output_tokens, config)

--- a/experiments/exp9-openrouter-evaluation-r2/test_run_inference.py
+++ b/experiments/exp9-openrouter-evaluation-r2/test_run_inference.py
@@ -1,0 +1,98 @@
+"""Unit tests for run_inference.py -- JSON extraction and pilot logic."""
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Helpers to exercise the JSON-extraction logic without making API calls
+# ---------------------------------------------------------------------------
+
+
+def _extract_json(raw_text: str) -> str:
+    """Mirror of the extraction logic in run_single()."""
+    start_idx = raw_text.find("{")
+    end_idx = raw_text.rfind("}")
+    if start_idx != -1 and end_idx != -1 and end_idx >= start_idx:
+        return raw_text[start_idx : end_idx + 1]
+    return raw_text
+
+
+class TestJsonExtraction(unittest.TestCase):
+    """C1 -- robust JSON extraction from model output."""
+
+    def test_plain_json_unchanged(self):
+        raw = '{"session_id": "run-86", "lens": "scout"}'
+        self.assertEqual(_extract_json(raw), raw)
+
+    def test_strips_json_fence(self):
+        raw = '```json\n{"session_id": "run-96"}\n```'
+        result = _extract_json(raw)
+        self.assertEqual(json.loads(result), {"session_id": "run-96"})
+
+    def test_strips_plain_fence(self):
+        raw = '```\n{"session_id": "run-106"}\n```'
+        result = _extract_json(raw)
+        self.assertEqual(json.loads(result), {"session_id": "run-106"})
+
+    def test_strips_prose_before_and_after(self):
+        raw = 'Here is the JSON:\n{"key": "value"}\nThat is all.'
+        result = _extract_json(raw)
+        self.assertEqual(json.loads(result), {"key": "value"})
+
+    def test_no_json_returns_raw(self):
+        raw = "No JSON object here at all."
+        self.assertEqual(_extract_json(raw), raw)
+
+    def test_empty_string(self):
+        self.assertEqual(_extract_json(""), "")
+
+    def test_nested_objects_preserved(self):
+        inner = {"approaches": [{"name": "A", "pros": []}], "recommendation": "A"}
+        raw = f"```json\n{json.dumps(inner)}\n```"
+        result = _extract_json(raw)
+        self.assertEqual(json.loads(result), inner)
+
+    def test_uses_last_closing_brace(self):
+        # Prose after the closing brace must be discarded
+        raw = '{"a": "b"} extra text with } stray brace'
+        result = _extract_json(raw)
+        # rfind picks the last '}', so result includes up to it
+        self.assertTrue(result.startswith("{"))
+        self.assertTrue(result.endswith("}"))
+
+
+class TestPilotBehavior(unittest.TestCase):
+    """C2 -- --pilot runs exactly one session per model (3 total)."""
+
+    def test_pilot_runs_all_three_models(self):
+        """Importing main() and inspecting PILOT_RUN_IDS covers all 3 models."""
+        sys.path.insert(0, str(Path(__file__).parent))
+        import run_inference as ri
+
+        self.assertEqual(set(ri.PILOT_RUN_IDS.keys()), {"gemma4", "haiku45", "sonnet5"})
+        self.assertEqual(ri.PILOT_RUN_IDS["gemma4"], "run-86")
+        self.assertEqual(ri.PILOT_RUN_IDS["haiku45"], "run-96")
+        self.assertEqual(ri.PILOT_RUN_IDS["sonnet5"], "run-106")
+
+    def test_no_pilot_break_in_source(self):
+        """The 'if args.pilot: break' line must not exist in run_inference.py."""
+        src = Path(__file__).parent / "run_inference.py"
+        text = src.read_text(encoding="utf-8")
+        # The fix removes this guard; if it reappears the pilot regresses
+        self.assertNotIn("if args.pilot:\n            break", text)
+
+
+class TestSkipExisting(unittest.TestCase):
+    """C3 -- --skip-existing skips run IDs that already have a session file."""
+
+    def test_skip_existing_flag_present(self):
+        src = Path(__file__).parent / "run_inference.py"
+        text = src.read_text(encoding="utf-8")
+        self.assertIn("--skip-existing", text)
+        self.assertIn("args.skip_existing", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes three bugs in `experiments/exp9-openrouter-evaluation-r2/run_inference.py` that prevented a valid pilot run for exp9.

## Bugs fixed

**1. `--pilot` exits after first model**

`if args.pilot: break` was placed inside the model loop, so only gemma4
ran during `--pilot`. haiku45 and sonnet5 were silently skipped. Removed
the break; pilot logic is fully handled by `args.runs = 1` and
`PILOT_RUN_IDS` selection above it.

**2. Models return tool-call syntax instead of JSON**

The runner prompt instructs models to clone a repo and run shell commands.
Without a system prompt, all three models attempted agentic tool use
instead of returning the required SCOUT JSON.

Fixes:
- Add a system message (role: system) framing the task as a parametric
  knowledge benchmark so models synthesise JSON from training knowledge
  rather than attempting execution
- Replace `OUTPUT_PATH` placeholder with `<your response content>` so
  models do not attempt filesystem writes they cannot perform
- Add `response_format={"type": "json_object"}` to the API call (all
  three models list this in `supported_parameters` on OpenRouter)
- Strip markdown fences in post-processing for models that emit them
  despite `response_format` (Claude via OpenRouter ignores the constraint)

**3. No way to resume interrupted runs**

Add `--skip-existing` flag to skip run IDs that already have a session
file, enabling clean resume after partial completion.

## Pilot validation

All three pilot sessions (run-86, run-96, run-106) return valid SCOUT JSON
with all required schema fields: `session_id`, `lens`, `relevant_files`,
`conventions`, `patterns`, `approaches`, `recommendation`.
