### PR TITLE
feat(aptu): add ai block to aptu.yml (required after aptu-github-app#61)

### DIFF
--- a/.github/aptu.yml
+++ b/.github/aptu.yml
@@ -4,3 +4,8 @@ triage:
 review:
   enabled: true
   instructions-file: .github/instructions/pr-review.md
+
+ai:
+  provider: gemini
+  model: models/gemini-3.1-flash-lite
+  api-key-secret: GEMINI_API_KEY


### PR DESCRIPTION
## Summary

After [clouatre-labs/aptu-github-app#61](https://github.com/clouatre-labs/aptu-github-app/pull/61)
merges, the Worker no longer falls back to operator-provided AI credentials. All repositories must
supply their own AI configuration via an `ai` block in `.github/aptu.yml`. Repositories without
this block will silently receive no triage or review dispatch.

This PR adds the required `ai` block before that breakage lands.

## Change

Adds to `.github/aptu.yml`:

```yaml
ai:
  provider: gemini
  model: models/gemini-3.1-flash-lite
  api-key-secret: GEMINI_API_KEY
```

`GEMINI_API_KEY` is an org-level Actions secret already available to all repositories in
`clouatre-labs`. No repository-level secret setup is required.

## Relates to

- clouatre-labs/aptu-github-app#61 (removes operator key fallback -- makes `ai` block required)
- clouatre-labs/aptu-github-app#59 (removes `ALLOWED_OWNERS` gate)
